### PR TITLE
docs: milestone 6 & 7 설계 문서 추가

### DIFF
--- a/docs/COLLECTION_ACHIEVEMENT_PRESTIGE_SYSTEM.md
+++ b/docs/COLLECTION_ACHIEVEMENT_PRESTIGE_SYSTEM.md
@@ -1,0 +1,1799 @@
+# Plantii - Collection, Achievement & Prestige System Technical Specification
+
+> **Version**: 1.0
+> **Date**: 2026-04-24
+> **Status**: Design
+> **Depends on**: Phase 1 (Core Simulation), Phase 2 (Garden/Economy), Scenario/Year System
+
+---
+
+## Table of Contents
+
+1. [System Overview & Goals](#1-system-overview--goals)
+2. [Sub-System 1: Plant Collection (Pokedex)](#2-sub-system-1-plant-collection-pokedex)
+3. [Sub-System 2: Achievement Badge System](#3-sub-system-2-achievement-badge-system)
+4. [Sub-System 3: Title System](#4-sub-system-3-title-system)
+5. [Sub-System 4: Prestige / New Game+ System](#5-sub-system-4-prestige--new-game-system)
+6. [Sub-System 5: Statistics Dashboard](#6-sub-system-5-statistics-dashboard)
+7. [Data Model & State Management](#7-data-model--state-management)
+8. [Database Schema (Migration Plan)](#8-database-schema-migration-plan)
+9. [API Design](#9-api-design)
+10. [System Interdependency Map](#10-system-interdependency-map)
+11. [User Experience Flow](#11-user-experience-flow)
+12. [Frontend Architecture](#12-frontend-architecture)
+13. [Implementation Roadmap](#13-implementation-roadmap)
+14. [Technical Considerations & Risks](#14-technical-considerations--risks)
+
+---
+
+## 1. System Overview & Goals
+
+### 1.1 Design Intent
+
+본 문서는 Plantii의 **장기 리플레이 동기 부여 시스템**을 정의한다. 3년 시나리오 1회차 엔딩 이후에도 플레이어가 지속적으로 게임에 복귀하도록 다음 5개 부분시스템을 설계한다:
+
+| Sub-System | 핵심 역할 | 리플레이 동기 |
+|------------|----------|-------------|
+| Plant Collection (도감) | 식물 수집 완성도 추적 | "전종 컴플리트" 도전 |
+| Achievement Badge (업적) | 마일스톤 달성 기록 | "모든 배지 수집" 목표 |
+| Title System (칭호) | 플레이어 성장 표현 | 사회적 인정, 자기 표현 |
+| Prestige / NG+ (프레스티지) | 회차 기반 누적 보너스 | "더 강하게 재시작" |
+| Statistics Dashboard (통계) | 전체 플레이 데이터 시각화 | 자기 기록 갱신, 비교 |
+
+### 1.2 Core Design Principle
+
+```
+1회차 엔딩(S/A/B/C/F) 달성
+  -> NG+로 재시작 가능
+  -> 회차 누적 보너스 적용 (프레스티지 레벨)
+  -> 이전 회차에서 못 채운 업적/도감 이어서 추적
+  -> 더 높은 엔딩 랭크 도전
+  -> 해금 시나리오/난이도 모드 개방
+```
+
+### 1.3 Existing Infrastructure (활용 가능 자원)
+
+| 기존 시스템 | 활용 방안 |
+|------------|---------|
+| `users.experience_points`, `users.level` | 칭호 진급 기준 데이터로 활용 |
+| `users.coins` | 프레스티지 캐리오버 자원 |
+| `user_plants.optimal_days_count` | 업적 달성 조건 (최적 일수 카운트) |
+| `user_plants.total_water_given` | 통계 대시보드 데이터 소스 |
+| `plants` 테이블 (15종) | 도감 기본 데이터 (돌연변이/희귀종 확장 기반) |
+| `GameSession` (시나리오 시스템) | 프레스티지 회차 연동 |
+| `YearlySnapshot` | 통계 대시보드 히스토리 |
+| `Collection.tsx` 페이지 | 도감 UI 기반 컴포넌트 |
+
+---
+
+## 2. Sub-System 1: Plant Collection (Pokedex)
+
+### 2.1 개요
+
+식물 도감은 플레이어가 지금까지 발견/수확/수집한 모든 식물 종의 카탈로그이다. 기본 15종에 더해 **돌연변이(Mutation)** 및 **희귀 품종(Rare Variant)** 시스템으로 수집 가능 항목을 확장한다.
+
+### 2.2 도감 엔트리 구조
+
+```typescript
+interface CollectionEntry {
+  plant_id: string;                // FK -> plants.id (e.g. "rose")
+  variant_id: string | null;       // 돌연변이/희귀종 ID (null이면 기본종)
+
+  // 발견 상태
+  discovery_status: 'undiscovered' | 'silhouette' | 'discovered' | 'mastered';
+  first_discovered_at: Date | null;
+  first_harvested_at: Date | null;
+
+  // 수집 통계
+  total_grown: number;             // 총 재배 시도 횟수
+  total_harvested: number;         // 총 성공 수확 횟수
+  best_health_at_harvest: number;  // 수확 시 최고 건강도
+  best_growth_time_days: number;   // 최단 성장 완료 일수
+  total_deaths: number;            // 해당 종 사망 횟수
+
+  // 마스터리 진행도
+  mastery_points: number;          // 마스터리 포인트 누적
+  mastery_level: 0 | 1 | 2 | 3;   // 0=미달, 1=Bronze, 2=Silver, 3=Gold
+}
+```
+
+### 2.3 Discovery Status Flow
+
+```
+[undiscovered]  -- 상점에서 씨앗 보기 or 이벤트 힌트 -->  [silhouette]
+[silhouette]    -- 최초 1회 심기 -->                      [discovered]
+[discovered]    -- mastery_level >= 3 달성 -->             [mastered]
+```
+
+- **undiscovered**: 도감에 "???" 아이콘, 이름 미공개
+- **silhouette**: 실루엣 아이콘, 이름 공개, 세부 정보 잠금
+- **discovered**: 전체 정보 공개, 성장 환경 가이드 열람 가능
+- **mastered**: 금테 아이콘, 해당 종 재배 시 경험치 +10% 보너스
+
+### 2.4 Mastery System
+
+각 식물 종별로 마스터리 포인트를 누적하여 마스터리 레벨을 진급한다.
+
+| 행동 | 마스터리 포인트 |
+|------|---------------|
+| 최초 심기 | +10 |
+| 수확 성공 | +20 |
+| 건강도 90+ 수확 | +10 (보너스) |
+| 최단 기록 경신 | +15 |
+| optimal_days 30일 이상 | +5 |
+| 돌연변이 발견 | +30 |
+| 해당 종 사망 시 | -5 |
+
+| 마스터리 레벨 | 필요 포인트 | 보상 |
+|-------------|-----------|------|
+| Bronze (1) | 50 | 도감 상세 페이지 해금 |
+| Silver (2) | 120 | 해당 종 성장속도 +5% 영구 보너스 |
+| Gold (3) | 250 | 해당 종 돌연변이 발생 확률 +10%, 도감 금테 |
+
+### 2.5 Mutation / Rare Variant System
+
+#### 2.5.1 돌연변이 (Mutation)
+
+돌연변이는 기본 15종에서 확률적으로 파생되는 시각적/기능적 변이체이다.
+
+```typescript
+interface PlantVariant {
+  id: string;                        // e.g. "rose_blue", "lettuce_giant"
+  base_plant_id: string;             // FK -> plants.id
+  name_ko: string;                   // "푸른 장미"
+  name_en: string;                   // "Blue Rose"
+  variant_type: 'mutation' | 'rare' | 'legendary';
+  rarity: 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
+
+  // 발생 조건
+  trigger: MutationTrigger;
+
+  // 변이 효과 (기본종 대비 변동)
+  stat_modifiers: {
+    growth_speed: number;            // 배율 (e.g. 0.8 = 20% 느림)
+    health_resilience: number;       // 배율
+    harvest_value: number;           // 수확 보상 배율
+    beauty_score: number;            // 정원 미관 점수 보너스
+  };
+
+  // 시각 표현
+  sprite_variant: string;            // 스프라이트 ID (별도 에셋)
+  color_tint?: string;               // 색상 변조 (에셋 없을 시 fallback)
+  particle_effect?: string;          // 특수 파티클 이펙트
+
+  // 도감 표시
+  description_ko: string;
+  discovery_hint_ko: string;         // "극한 환경에서 발견된다는 소문이..."
+}
+
+interface MutationTrigger {
+  type: 'environment_extreme'        // 극한 환경 유지 시
+      | 'perfect_care'               // 완벽 관리 조건 달성 시
+      | 'seasonal'                   // 특정 계절에만
+      | 'consecutive_harvest'        // 연속 수확 시
+      | 'cross_proximity'            // 특정 식물 인접 배치 시
+      | 'prestige_exclusive'         // NG+ 전용
+      | 'random';                    // 순수 확률
+  conditions: Record<string, any>;   // 세부 조건 JSON
+  base_probability: number;          // 기본 발생 확률 (0.0 ~ 1.0)
+}
+```
+
+#### 2.5.2 돌연변이 카탈로그 (초기 설계)
+
+| ID | 기본종 | 변이명 | 등급 | 발생 조건 | 기본 확률 |
+|----|-------|--------|------|----------|---------|
+| rose_blue | 장미 | 푸른 장미 | Epic | 기온 5C 이하에서 3일 생존 + 건강 70+ | 3% |
+| rose_black | 장미 | 검은 장미 | Legendary | NG+2 이상 + 밤(winter)에 심기 | 1% |
+| lettuce_giant | 상추 | 거대 상추 | Uncommon | 연속 3회 수확 + 최적 환경 유지 | 8% |
+| cactus_flower | 선인장 | 꽃피는 선인장 | Rare | 물 주기 최소화 + 30일 생존 | 5% |
+| basil_purple | 바질 | 보라 바질 | Uncommon | 광량 120% 이상 유지 7일 | 10% |
+| mint_chocolate | 민트 | 초코 민트 | Rare | 민트 + 토마토 인접 배치 3주 | 5% |
+| sunflower_double | 해바라기 | 쌍둥이 해바라기 | Rare | 건강도 95+ 수확 + 여름 계절 | 4% |
+| orchid_ghost | 난초 | 유령 난초 | Legendary | NG+1 이상 + 겨울 봄 연속 재배 | 1.5% |
+| monstera_variegata | 몬스테라 | 무늬 몬스테라 | Epic | 광량 변동 ±30% 반복 7일 | 3% |
+| tomato_golden | 토마토 | 황금 토마토 | Rare | 최적 환경 20일 연속 유지 | 4% |
+| aloe_crystal | 알로에 | 크리스탈 알로에 | Epic | 습도 30% 이하 + 온도 35C 이상 10일 | 2.5% |
+| lavender_white | 라벤더 | 흰 라벤더 | Uncommon | 겨울 재배 + 건강도 80+ 유지 | 7% |
+| chili_reaper | 고추 | 리퍼 고추 | Epic | 연속 5회 수확 + 온도 30C+ | 3% |
+| tulip_rainbow | 튤립 | 무지개 튤립 | Legendary | 15종 전종 수확 달성 후 튤립 재배 | 2% |
+| rubber_bonsai | 고무나무 | 분재 고무나무 | Rare | 성장 50% 시점에 물 주기 중단 7일 | 5% |
+| echeveria_crystal | 에케베리아 | 수정 에케베리아 | Epic | NG+1 + 겨울 + 습도 20% 이하 | 2% |
+
+총 수집 가능 항목: **기본 15종 + 변이 16종 = 31종** (향후 확장 가능)
+
+#### 2.5.3 돌연변이 발생 로직
+
+```typescript
+// simulation.service.ts 확장 - 매 시뮬레이션 틱에서 호출
+class MutationService {
+  /**
+   * 시뮬레이션 틱마다 각 활성 식물에 대해 돌연변이 발생 체크
+   * - 이미 variant가 있는 식물은 스킵
+   * - 발생 조건 충족 여부 확인 -> 확률 롤
+   */
+  static async checkMutation(
+    userPlant: UserPlant,
+    gameSession: GameSession,
+    environmentHistory: EnvironmentSnapshot[]
+  ): Promise<PlantVariant | null> {
+
+    if (userPlant.variant_id) return null; // 이미 변이체
+
+    const eligibleVariants = await this.getEligibleVariants(
+      userPlant.plant_id,
+      userPlant,
+      gameSession,
+      environmentHistory
+    );
+
+    for (const variant of eligibleVariants) {
+      let probability = variant.trigger.base_probability;
+
+      // 프레스티지 보너스 적용
+      probability += gameSession.prestige_level * 0.01; // 회차당 +1%
+
+      // 마스터리 보너스 적용
+      const mastery = await CollectionService.getMasteryLevel(
+        gameSession.user_id, userPlant.plant_id
+      );
+      if (mastery >= 3) probability += 0.10; // Gold 마스터리 시 +10%
+
+      // 확률 롤
+      if (Math.random() < probability) {
+        await this.applyMutation(userPlant, variant);
+        await CollectionService.recordDiscovery(
+          gameSession.user_id, variant.base_plant_id, variant.id
+        );
+        return variant;
+      }
+    }
+
+    return null;
+  }
+}
+```
+
+### 2.6 도감 완성도 계산
+
+```typescript
+interface CollectionCompletionRate {
+  // 기본종 (15종)
+  base_discovered: number;           // 발견한 기본종 수
+  base_harvested: number;            // 수확한 기본종 수
+  base_mastered: number;             // 마스터한 기본종 수
+  base_total: 15;
+  base_completion_percent: number;   // harvested / 15 * 100
+
+  // 변이종
+  variant_discovered: number;
+  variant_total: number;             // 전체 변이종 수 (16)
+  variant_completion_percent: number;
+
+  // 전체
+  overall_completion_percent: number; // (base_harvested + variant_discovered) / 31 * 100
+
+  // 마스터리 통합
+  total_mastery_points: number;
+  average_mastery_level: number;
+}
+```
+
+---
+
+## 3. Sub-System 2: Achievement Badge System
+
+### 3.1 개요
+
+업적 배지는 특정 마일스톤 달성 시 자동 부여되는 일회성 보상이다. 업적은 **회차를 넘어 영구 유지**되며, NG+ 후에도 리셋되지 않는다.
+
+### 3.2 업적 데이터 구조
+
+```typescript
+interface Achievement {
+  id: string;                        // e.g. "first_harvest"
+  category: AchievementCategory;
+  name_ko: string;
+  name_en: string;
+  description_ko: string;
+  icon_url: string;
+  rarity: 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
+
+  // 달성 조건
+  condition: AchievementCondition;
+
+  // 보상
+  rewards: {
+    experience: number;
+    coins: number;
+    title_unlock?: string;           // 연결된 칭호 ID
+    cosmetic_unlock?: string;        // 장식/테마 해금
+  };
+
+  // 시리즈 (단계별 업적)
+  series_id?: string;                // 같은 시리즈의 업적 그룹 ID
+  series_order?: number;             // 시리즈 내 순서 (1,2,3)
+
+  // 숨김 업적 여부
+  is_hidden: boolean;                // true면 달성 전까지 "???" 표시
+}
+
+type AchievementCategory =
+  | 'cultivation'      // 재배 관련
+  | 'collection'       // 도감 관련
+  | 'economy'          // 경제 관련
+  | 'mastery'          // 마스터리 관련
+  | 'prestige'         // 프레스티지 관련
+  | 'challenge'        // 도전 관련
+  | 'social'           // 사회적 (칭호, 랭크)
+  | 'secret';          // 숨겨진 업적
+
+interface AchievementCondition {
+  type: string;
+  threshold: number | string;
+  // 복합 조건 시 AND/OR 연산
+  operator?: 'AND' | 'OR';
+  sub_conditions?: AchievementCondition[];
+}
+
+interface UserAchievement {
+  user_id: string;
+  achievement_id: string;
+  unlocked_at: Date;
+  unlocked_in_session: string;       // 어느 게임 세션(회차)에서 달성했는지
+  progress: number;                  // 진행도 (0.0~1.0) - 미달성 시 추적용
+  is_notified: boolean;              // 알림 표시 완료 여부
+}
+```
+
+### 3.3 Achievement Catalog
+
+#### 3.3.1 Cultivation (재배) 업적
+
+| ID | 이름 | 조건 | 등급 | 보상 |
+|----|------|------|------|------|
+| first_seed | 첫 씨앗 | 첫 식물 심기 | Common | 50 EXP |
+| first_harvest | 첫 수확 | 첫 수확 성공 | Common | 100 EXP, 50 Coins |
+| green_thumb_1 | 초록 손가락 I | 10회 수확 | Common | 200 EXP |
+| green_thumb_2 | 초록 손가락 II | 50회 수확 | Uncommon | 500 EXP, 100 Coins |
+| green_thumb_3 | 초록 손가락 III | 200회 수확 | Rare | 1000 EXP, 300 Coins |
+| perfect_harvest | 완벽한 수확 | 건강도 100 수확 | Uncommon | 300 EXP |
+| speed_grower | 스피드 재배사 | 기본 성장 일수 80% 이내 수확 | Rare | 500 EXP |
+| survivor | 생존자 | 건강도 10 이하에서 100으로 회복 | Uncommon | 200 EXP |
+| no_death_run | 무사고 운영 | 1회차 전체 식물 사망 0 | Epic | 1500 EXP, 500 Coins |
+| watering_master | 물 주기 달인 | 누적 500회 물 주기 | Uncommon | 300 EXP |
+
+#### 3.3.2 Collection (도감) 업적
+
+| ID | 이름 | 조건 | 등급 | 보상 |
+|----|------|------|------|------|
+| collector_1 | 초보 수집가 | 5종 수확 | Common | 200 EXP |
+| collector_2 | 숙련 수집가 | 10종 수확 | Uncommon | 500 EXP, 200 Coins |
+| collector_3 | 마스터 수집가 | 15종 전종 수확 | Epic | 2000 EXP, 1000 Coins, Title: "식물학자" |
+| mutation_finder | 변이 발견자 | 돌연변이 1종 발견 | Uncommon | 300 EXP |
+| mutation_hunter | 변이 사냥꾼 | 돌연변이 5종 발견 | Rare | 800 EXP |
+| mutation_master | 변이 마스터 | 돌연변이 10종 발견 | Epic | 2000 EXP, Title: "유전학자" |
+| legendary_find | 전설의 발견 | Legendary 등급 변이 발견 | Legendary | 3000 EXP, 1500 Coins |
+| full_pokedex | 도감 완성 | 기본+변이 전종 발견 | Legendary | 5000 EXP, Title: "마스터 보타니스트" |
+
+#### 3.3.3 Economy (경제) 업적
+
+| ID | 이름 | 조건 | 등급 | 보상 |
+|----|------|------|------|------|
+| first_profit | 첫 수익 | 누적 매출 1,000 | Common | 100 EXP |
+| merchant_1 | 사업가 I | 누적 매출 10,000 | Uncommon | 300 EXP |
+| merchant_2 | 사업가 II | 누적 매출 100,000 | Rare | 800 EXP |
+| merchant_3 | 재벌 정원사 | 누적 매출 500,000 | Epic | 2000 EXP, Title: "재벌 정원사" |
+| big_spender | 큰손 | 단일 구매 5,000 코인 이상 | Uncommon | 200 EXP |
+
+#### 3.3.4 Mastery (마스터리) 업적
+
+| ID | 이름 | 조건 | 등급 | 보상 |
+|----|------|------|------|------|
+| first_mastery | 첫 마스터리 | 아무 종 Gold 마스터리 달성 | Rare | 500 EXP |
+| mastery_5 | 다재다능 | 5종 Gold 마스터리 | Epic | 1500 EXP |
+| mastery_all | 만물박사 | 15종 전종 Gold 마스터리 | Legendary | 5000 EXP, Title: "그랜드 마스터" |
+| optimal_30 | 최적 환경 전문가 | 단일 식물 optimal_days 30일 | Uncommon | 300 EXP |
+
+#### 3.3.5 Prestige (프레스티지) 업적
+
+| ID | 이름 | 조건 | 등급 | 보상 |
+|----|------|------|------|------|
+| ng_plus_1 | 재도전 | NG+ 1회 시작 | Common | 500 EXP |
+| ng_plus_3 | 집념의 정원사 | NG+ 3회 시작 | Uncommon | 1000 EXP |
+| ng_plus_5 | 전설의 귀환 | NG+ 5회 시작 | Rare | 2000 EXP |
+| s_rank | S랭크 달성 | S랭크 엔딩 | Epic | 3000 EXP, Title: "전설의 보타니스트" |
+| s_rank_hard | 하드코어 S | Hard 모드 S랭크 | Legendary | 5000 EXP, Title: "식물의 신" |
+| all_endings | 엔딩 수집가 | S/A/B/C/F 전체 엔딩 경험 | Epic | 2000 EXP |
+
+#### 3.3.6 Secret (숨김) 업적
+
+| ID | 이름 | 조건 | 등급 | 보상 |
+|----|------|------|------|------|
+| night_owl | 밤의 정원사 | 자정~새벽 5시에 10회 접속 | Uncommon | 200 EXP |
+| phoenix | 불사조 정원 | 전멸 후 같은 회차에 전종 수확 | Legendary | 5000 EXP |
+| minimalist | 미니멀리스트 | 4플롯만으로 B랭크 이상 | Epic | 2000 EXP |
+| speed_run | 스피드런 | 100실시간일 이내 엔딩 도달 | Epic | 2000 EXP |
+
+### 3.4 Achievement Evaluation Engine
+
+```typescript
+class AchievementEvaluator {
+  /**
+   * 게임 내 주요 이벤트 발생 시 호출된다.
+   * 이벤트 기반으로 관련 업적만 체크하여 성능 보장.
+   */
+  static async evaluate(
+    userId: string,
+    event: GameEvent
+  ): Promise<UserAchievement[]> {
+
+    const newlyUnlocked: UserAchievement[] = [];
+
+    // 이벤트 타입별 관련 업적만 필터링
+    const candidates = await this.getCandidateAchievements(event.type);
+
+    for (const achievement of candidates) {
+      // 이미 달성했는지 확인
+      const existing = await this.getUserAchievement(userId, achievement.id);
+      if (existing?.unlocked_at) continue;
+
+      // 조건 평가
+      const { met, progress } = await this.evaluateCondition(
+        userId, achievement.condition, event
+      );
+
+      if (met) {
+        const unlocked = await this.unlock(userId, achievement);
+        newlyUnlocked.push(unlocked);
+      } else {
+        // 진행도만 업데이트
+        await this.updateProgress(userId, achievement.id, progress);
+      }
+    }
+
+    return newlyUnlocked;
+  }
+
+  // 이벤트 -> 업적 매핑 테이블
+  private static eventAchievementMap: Record<string, string[]> = {
+    'plant_created':   ['first_seed'],
+    'plant_harvested': ['first_harvest', 'green_thumb_*', 'perfect_harvest', 'speed_grower', 'collector_*'],
+    'plant_died':      ['no_death_run'],
+    'plant_watered':   ['watering_master'],
+    'mutation_found':  ['mutation_finder', 'mutation_hunter', 'mutation_master', 'legendary_find'],
+    'session_ended':   ['s_rank', 'all_endings', 'no_death_run'],
+    'ng_plus_started': ['ng_plus_*'],
+    'revenue_changed': ['first_profit', 'merchant_*'],
+    'mastery_changed': ['first_mastery', 'mastery_*'],
+  };
+}
+```
+
+---
+
+## 4. Sub-System 3: Title System
+
+### 4.1 개요
+
+칭호는 플레이어의 숙련도와 업적을 나타내는 표시 이름이다. 프로필, 정원 방문 시, 리더보드에 표시된다.
+
+### 4.2 칭호 데이터 구조
+
+```typescript
+interface Title {
+  id: string;
+  name_ko: string;
+  name_en: string;
+  description_ko: string;
+  category: 'progression' | 'achievement' | 'prestige' | 'special';
+  rarity: 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
+
+  // 해금 조건 (하나 이상 충족)
+  unlock_condition: {
+    type: 'level' | 'achievement' | 'prestige' | 'collection' | 'composite';
+    value: string | number;
+  };
+
+  // 특수 효과 (선택 장착 시)
+  passive_bonus?: {
+    type: string;
+    value: number;
+    description_ko: string;
+  };
+}
+
+interface UserTitle {
+  user_id: string;
+  title_id: string;
+  unlocked_at: Date;
+  is_equipped: boolean;              // 현재 장착 중인 칭호
+}
+```
+
+### 4.3 Progression Title Ladder (진급 사다리)
+
+메인 칭호 라인은 레벨/경험치 기반으로 자동 진급한다.
+
+| 순서 | 칭호 (KO) | 칭호 (EN) | 해금 조건 | Passive Bonus |
+|------|----------|-----------|----------|---------------|
+| 1 | 새싹 정원사 | Sprout Gardener | 게임 시작 (기본) | 없음 |
+| 2 | 초보 정원사 | Novice Gardener | Level 5 | 물 효율 +3% |
+| 3 | 견습 정원사 | Apprentice Gardener | Level 10 | 성장속도 +3% |
+| 4 | 숙련 정원사 | Skilled Gardener | Level 20 | 물 효율 +5% |
+| 5 | 전문 정원사 | Expert Gardener | Level 30 + 수확 50회 | 성장속도 +5% |
+| 6 | 마스터 정원사 | Master Gardener | Level 40 + 10종 수확 | 물 효율 +8%, 성장속도 +5% |
+| 7 | 그랜드 마스터 | Grand Master | Level 50 + 15종 마스터리 Gold | 전체 보너스 +10% |
+| 8 | 보타니스트 | Botanist | S랭크 엔딩 + 도감 80% | 돌연변이 확률 +5% |
+| 9 | 마스터 보타니스트 | Master Botanist | S랭크 + 도감 100% + NG+3 | 전체 보너스 +15% |
+
+### 4.4 Achievement-Linked Titles (업적 연동 칭호)
+
+업적 달성 시 특별 칭호가 해금된다 (3.3절 업적 테이블의 `title_unlock` 참조).
+
+| 칭호 | 연동 업적 | 카테고리 |
+|------|----------|---------|
+| 식물학자 | collector_3 (15종 전종 수확) | Achievement |
+| 유전학자 | mutation_master (변이 10종) | Achievement |
+| 재벌 정원사 | merchant_3 (매출 500K) | Achievement |
+| 전설의 보타니스트 | s_rank (S랭크 엔딩) | Achievement |
+| 식물의 신 | s_rank_hard (Hard S랭크) | Achievement |
+
+### 4.5 Prestige Titles (프레스티지 전용 칭호)
+
+| 칭호 | 해금 조건 | Passive Bonus |
+|------|----------|---------------|
+| 재도전자 | NG+1 시작 | 초기 코인 +10% |
+| 숙련 재도전자 | NG+3 시작 | 초기 코인 +15%, 경험치 +5% |
+| 영원의 정원사 | NG+5 시작 | 초기 코인 +20%, 전체 보너스 +5% |
+| 초월자 | NG+10 시작 | 모든 보너스 +10% |
+
+### 4.6 칭호 장착 시스템
+
+- 플레이어는 해금된 칭호 중 **1개만 활성 장착** 가능
+- 장착된 칭호의 `passive_bonus`가 게임플레이에 적용됨
+- 칭호 변경은 프로필 페이지에서 자유롭게 가능 (쿨타임 없음)
+
+---
+
+## 5. Sub-System 4: Prestige / New Game+ System
+
+### 5.1 개요
+
+프레스티지(NG+)는 1회차 엔딩 후 새 게임을 시작할 때 이전 회차의 누적 보너스를 받는 시스템이다.
+
+### 5.2 NG+ 진입 조건 및 흐름
+
+```
+[ENDING 화면] (S/A/B/C/F 어떤 엔딩이든)
+    |
+    v
+[CREDITS 롤]
+    |
+    v
+[POST-GAME 선택 화면]
+    |
+    +-- [Continue Playing] --> 현재 세션 유지 (샌드박스 모드)
+    |
+    +-- [New Game+] --> 프레스티지 진입
+           |
+           v
+         [NG+ 설정 화면]
+           - 난이도 선택 (Normal / Hard / Extreme)
+           - 해금 시나리오 선택
+           - 캐리오버 보너스 미리보기
+           |
+           v
+         [새 GameSession 생성 (prestige_level++)]
+           |
+           v
+         [Year 1 Spring - 보너스 적용 상태로 시작]
+```
+
+### 5.3 Prestige Data Model
+
+```typescript
+interface PrestigeProfile {
+  user_id: string;
+
+  // 프레스티지 핵심 데이터
+  prestige_level: number;            // 0 = 첫 회차, 1 = NG+1, 2 = NG+2...
+  total_playthroughs: number;        // 완료한 총 회차 수
+  best_ending_rank: 'S' | 'A' | 'B' | 'C' | 'F';
+
+  // 엔딩 히스토리
+  ending_history: EndingRecord[];
+
+  // 누적 캐리오버 보너스
+  carryover: PrestigeCarryover;
+
+  // 해금 콘텐츠
+  unlocked_scenarios: string[];      // 해금된 시나리오 ID 목록
+  unlocked_difficulty_modes: string[];
+  unlocked_cosmetics: string[];
+
+  // 글로벌 통계 (회차 통틀어)
+  global_stats: {
+    total_plants_ever_grown: number;
+    total_plants_ever_harvested: number;
+    total_coins_ever_earned: number;
+    total_play_time_hours: number;
+    total_mutations_found: number;
+  };
+}
+
+interface EndingRecord {
+  session_id: string;
+  prestige_level: number;            // 해당 회차의 프레스티지 레벨
+  ending_rank: 'S' | 'A' | 'B' | 'C' | 'F';
+  difficulty: 'normal' | 'hard' | 'extreme';
+  scenario_id: string;
+  final_revenue: number;
+  final_collection_rate: number;
+  final_satisfaction: number;
+  completed_at: Date;
+  play_duration_days: number;        // 실시간 플레이 일수
+}
+
+interface PrestigeCarryover {
+  // 경제 보너스
+  starting_coins_bonus: number;      // 초기 코인 추가량
+  revenue_multiplier: number;        // 매출 배율 (1.0 기반)
+
+  // 성장 보너스
+  growth_speed_bonus: number;        // 성장속도 배율
+  health_resilience_bonus: number;   // 건강도 감소 저항
+
+  // 수집 보너스
+  mutation_probability_bonus: number; // 돌연변이 확률 추가
+  mastery_gain_bonus: number;        // 마스터리 포인트 획득 배율
+
+  // 구조적 보너스
+  starting_plots: number;            // 시작 시 해금 플롯 수
+  starting_tools: string[];          // 시작 시 보유 도구 목록
+}
+```
+
+### 5.4 Prestige Level Bonuses (회차별 누적 보너스)
+
+| Prestige Lv | 초기 코인 | 매출 배율 | 성장속도 | 돌연변이 확률 | 시작 플롯 | 추가 해금 |
+|-------------|----------|----------|---------|-------------|---------|---------|
+| 0 (1회차) | 1,000 | x1.0 | x1.0 | +0% | 4개 | - |
+| 1 (NG+1) | 1,500 | x1.05 | x1.05 | +2% | 5개 | Hard 모드 |
+| 2 (NG+2) | 2,000 | x1.10 | x1.08 | +4% | 5개 | 시나리오 B |
+| 3 (NG+3) | 2,500 | x1.15 | x1.10 | +6% | 6개 | Extreme 모드 |
+| 4 (NG+4) | 3,000 | x1.18 | x1.12 | +7% | 6개 | 시나리오 C |
+| 5 (NG+5) | 3,500 | x1.20 | x1.15 | +8% | 7개 | 전설 시나리오 |
+| 6~9 | +300/lv | +0.02/lv | +0.02/lv | +1%/lv | 7개 | 코스메틱 |
+| 10+ | +200/lv | +0.01/lv | +0.01/lv | +0.5%/lv | 8개 (상한) | - |
+
+**보너스 상한 (Hard Cap)**:
+- 매출 배율: x1.50 (50% 증가 상한)
+- 성장속도: x1.30 (30% 증가 상한)
+- 돌연변이 확률: +20% 상한
+- 시작 플롯: 8개 상한 (최대 9개 중)
+
+### 5.5 Difficulty Modes (난이도 모드)
+
+| 모드 | 해금 조건 | 변경 사항 |
+|------|----------|----------|
+| Normal | 기본 | 기본 밸런스, 시나리오 시스템 설계 기준 |
+| Hard | NG+1 이상 | 환경 변동 +50%, 식물 사망 속도 +30%, 자원 획득 -20%, 목표 기준치 +25% |
+| Extreme | NG+3 이상 | 환경 변동 +100%, 사망 속도 +60%, 자원 -40%, 목표 +50%, 랜덤 재해 이벤트 |
+
+### 5.6 Unlockable Scenarios (해금 시나리오)
+
+| 시나리오 ID | 이름 | 해금 조건 | 설명 |
+|------------|------|----------|------|
+| main | 최고의 보타닉 가든 | 기본 | 표준 3년 시나리오 |
+| scenario_b | 사막의 오아시스 | NG+2 | 건조 기후, 다육/선인장 특화, 물 자원 부족 |
+| scenario_c | 열대 정글 파라다이스 | NG+4 | 열대 기후, 관엽식물 특화, 병충해 강화 |
+| scenario_legend | 전설의 식물원 복원 | NG+5 + S랭크 1회 | 1년 시한, 모든 전설 변이 해금 기회, 극한 난이도 |
+| scenario_zen | 젠 가든 | 모든 엔딩 수집 | 시간 제한 없음, 평화로운 샌드박스, 힐링 모드 |
+
+### 5.7 NG+ 시 리셋/유지 항목
+
+| 항목 | NG+ 시 처리 | 근거 |
+|------|-----------|------|
+| GameSession | **새로 생성** | 새 게임이므로 |
+| 정원 그리드/식물 | **리셋** | 새로 시작 |
+| 코인 | **리셋 + 프레스티지 보너스** | 초기 코인 = 1000 + starting_coins_bonus |
+| 레벨/경험치 | **리셋** | 회차 내 성장 재경험 |
+| 도구/업그레이드 | **리셋** (일부 유지) | starting_tools로 일부 캐리오버 |
+| 업적 | **영구 유지** | 회차 독립 |
+| 도감 discovery | **영구 유지** | 수집 진행 유지 |
+| 도감 mastery 포인트 | **영구 유지** | 누적 시스템 |
+| 칭호 | **영구 유지** | 장착 칭호 효과 유지 |
+| 통계 | **영구 유지** (회차별 분리 저장) | 글로벌 통계 누적 |
+| 프레스티지 프로필 | **영구 유지** (레벨 증가) | 핵심 메타 진행 |
+
+---
+
+## 6. Sub-System 5: Statistics Dashboard
+
+### 6.1 개요
+
+통계 대시보드는 플레이어의 전체 게임 플레이 데이터를 시각화하는 종합 화면이다.
+
+### 6.2 Dashboard Layout
+
+```
++-------------------------------------------------------------------+
+| [Statistics Dashboard]                         Prestige Lv: 3     |
++-------------------------------------------------------------------+
+|                                                                   |
+| [Current Playthrough]        [All-Time Records]                   |
+| +-----------------------+   +--------------------------+          |
+| | Session: NG+3         |   | Total Playthroughs: 3    |          |
+| | Day: 87 / 156         |   | Best Rank: S             |          |
+| | Year 2 - Summer       |   | Total Play Time: 312h    |          |
+| | Revenue: 42,350       |   | Total Harvests: 847      |          |
+| | Collection: 9/15      |   | Total Mutations: 12      |          |
+| | Satisfaction: 72      |   | Total Coins Earned: 1.2M |          |
+| +-----------------------+   +--------------------------+          |
+|                                                                   |
+| [Revenue Chart - Line Graph]                                      |
+| +-------------------------------------------------------------+  |
+| |  ^                                    _____                  |  |
+| |  |                               ____/     \                 |  |
+| |  |                          ____/            \_____          |  |
+| |  |                     ____/                       \         |  |
+| |  |                ____/                              |       |  |
+| |  |           ____/                                   |       |  |
+| |  |      ____/                                        |       |  |
+| |  | ____/                                             |       |  |
+| |  +----------------------------------------------------->    |  |
+| |   Y1-Sp  Y1-Su  Y1-Au  Y1-Wi  Y2-Sp  Y2-Su  ...          |  |
+| +-------------------------------------------------------------+  |
+|                                                                   |
+| [Species Mastery]           [Ending History]                      |
+| +-----------------------+   +--------------------------+          |
+| | Rose:    [###---] S   |   | Run 1: B rank (Normal)   |          |
+| | Cactus:  [####--] G   |   | Run 2: A rank (Normal)   |          |
+| | Lettuce: [######] G   |   | Run 3: S rank (Hard)     |          |
+| | Basil:   [##----] B   |   |                          |          |
+| | ...                   |   |                          |          |
+| +-----------------------+   +--------------------------+          |
+|                                                                   |
+| [Achievement Progress]                                            |
+| +-------------------------------------------------------------+  |
+| | Unlocked: 24 / 42  (57%)                                    |  |
+| | [###########################-----------------------]          |  |
+| | Recent: "변이 사냥꾼" (2 hours ago)                          |  |
+| +-------------------------------------------------------------+  |
++-------------------------------------------------------------------+
+```
+
+### 6.3 Statistics Data Model
+
+```typescript
+interface StatisticsDashboard {
+  // 현재 회차 통계
+  current_session: {
+    session_id: string;
+    prestige_level: number;
+    difficulty: string;
+    scenario: string;
+    elapsed_days: number;
+    total_days: number;
+    current_year: number;
+    current_season: string;
+    revenue: number;
+    collection_rate: number;
+    satisfaction: number;
+    plants_active: number;
+    plants_harvested: number;
+    plants_died: number;
+    mutations_found: number;
+  };
+
+  // 글로벌 (전체 회차) 통계
+  global: {
+    total_playthroughs: number;
+    best_ending_rank: string;
+    total_play_time_hours: number;
+    total_plants_grown: number;
+    total_plants_harvested: number;
+    total_plants_died: number;
+    total_coins_earned: number;
+    total_mutations_found: number;
+    unique_mutations_found: number;
+    achievement_count: number;
+    achievement_total: number;
+    collection_base_rate: number;      // 기본종 도감 완성률
+    collection_variant_rate: number;   // 변이종 도감 완성률
+    collection_overall_rate: number;   // 전체 도감 완성률
+  };
+
+  // 시계열 데이터 (차트용)
+  revenue_history: { week: number; revenue: number }[];
+  satisfaction_history: { week: number; score: number }[];
+  collection_history: { week: number; count: number }[];
+
+  // 종별 마스터리 현황
+  species_mastery: {
+    plant_id: string;
+    name_ko: string;
+    mastery_level: number;
+    mastery_points: number;
+    total_grown: number;
+    total_harvested: number;
+    variants_found: string[];
+  }[];
+
+  // 엔딩 히스토리
+  ending_history: EndingRecord[];
+
+  // 최근 업적
+  recent_achievements: {
+    achievement_id: string;
+    name_ko: string;
+    unlocked_at: Date;
+    rarity: string;
+  }[];
+}
+```
+
+### 6.4 Chart Specifications
+
+| 차트 | 유형 | X축 | Y축 | 데이터 소스 |
+|------|------|-----|-----|-----------|
+| 매출 추이 | Line Chart | 주차 (Week) | 누적 매출 (Coins) | GameSession.weekly_revenue_log |
+| 만족도 추이 | Line Chart | 주차 | 만족도 (0~100) | GameSession.weekly_satisfaction_log |
+| 도감 수집 추이 | Step Chart | 주차 | 수집 종 수 | CollectionEntry.first_harvested_at |
+| 종별 마스터리 | Horizontal Bar | 식물 종 | 마스터리 포인트 | CollectionEntry.mastery_points |
+| 엔딩 히스토리 | Timeline | 회차 | 랭크 | EndingRecord |
+| 업적 달성률 | Donut Chart | 카테고리별 | 달성/미달성 | UserAchievement |
+| 회차별 비교 | Grouped Bar | 회차 | 매출/수집률/만족도 | EndingRecord |
+
+---
+
+## 7. Data Model & State Management
+
+### 7.1 State Hierarchy
+
+```
+User (영구)
+  |
+  +-- PrestigeProfile (영구, 회차 독립)
+  |     +-- prestige_level
+  |     +-- ending_history[]
+  |     +-- global_stats
+  |     +-- unlocked_scenarios[]
+  |     +-- unlocked_difficulty_modes[]
+  |
+  +-- CollectionEntry[] (영구, 회차 독립)
+  |     +-- per plant/variant: discovery_status, mastery
+  |
+  +-- UserAchievement[] (영구, 회차 독립)
+  |
+  +-- UserTitle[] (영구, 회차 독립)
+  |     +-- equipped_title_id
+  |
+  +-- GameSession (회차별)
+        +-- year/season/week state
+        +-- in-session stats
+        +-- revenue/collection/satisfaction
+```
+
+### 7.2 Redux State Structure (Frontend)
+
+```typescript
+interface RootState {
+  auth: AuthState;
+
+  // 현재 게임 세션 (회차별 리셋)
+  gameSession: {
+    current: GameSession | null;
+    loading: boolean;
+  };
+
+  // 영구 메타 데이터 (회차 독립)
+  meta: {
+    prestige: PrestigeProfile;
+    collection: CollectionEntry[];
+    achievements: UserAchievement[];
+    titles: UserTitle[];
+    equippedTitle: Title | null;
+  };
+
+  // 통계 (캐시)
+  statistics: {
+    dashboard: StatisticsDashboard | null;
+    loading: boolean;
+    lastFetched: Date | null;
+  };
+
+  // UI 상태
+  ui: {
+    achievementNotification: UserAchievement | null; // 팝업 큐
+    mutationNotification: PlantVariant | null;
+    titleUnlockNotification: Title | null;
+  };
+}
+```
+
+### 7.3 State Persistence Strategy
+
+| 데이터 | 저장소 | 동기화 전략 |
+|--------|-------|-----------|
+| PrestigeProfile | PostgreSQL (서버) | API 호출로 동기화, 로컬 캐시 |
+| CollectionEntry[] | PostgreSQL (서버) | 이벤트 발생 시 즉시 동기화 |
+| UserAchievement[] | PostgreSQL (서버) | 이벤트 발생 시 즉시 동기화, 미알림 큐 로컬 저장 |
+| UserTitle[] | PostgreSQL (서버) | 장착 변경 시 즉시 동기화 |
+| GameSession | PostgreSQL (서버) | 시뮬레이션 틱마다 동기화 |
+| StatisticsDashboard | 서버 집계 쿼리 | 대시보드 접근 시 Lazy Load, 5분 캐시 |
+| UI 알림 큐 | localStorage | 클라이언트 전용 |
+
+---
+
+## 8. Database Schema (Migration Plan)
+
+### 8.1 New Tables
+
+```sql
+-- ============================================================
+-- Table: prestige_profiles
+-- 프레스티지 메타 데이터 (유저당 1개, 영구)
+-- ============================================================
+CREATE TABLE prestige_profiles (
+  user_id         UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  prestige_level  INTEGER NOT NULL DEFAULT 0,
+  total_playthroughs INTEGER NOT NULL DEFAULT 0,
+  best_ending_rank VARCHAR(1) DEFAULT NULL,  -- 'S','A','B','C','F'
+
+  -- 캐리오버 보너스 (JSON으로 유연하게)
+  carryover       JSONB NOT NULL DEFAULT '{
+    "starting_coins_bonus": 0,
+    "revenue_multiplier": 1.0,
+    "growth_speed_bonus": 1.0,
+    "health_resilience_bonus": 1.0,
+    "mutation_probability_bonus": 0.0,
+    "mastery_gain_bonus": 1.0,
+    "starting_plots": 4,
+    "starting_tools": []
+  }',
+
+  -- 해금 콘텐츠
+  unlocked_scenarios      TEXT[] NOT NULL DEFAULT ARRAY['main'],
+  unlocked_difficulty_modes TEXT[] NOT NULL DEFAULT ARRAY['normal'],
+  unlocked_cosmetics      TEXT[] NOT NULL DEFAULT '{}',
+
+  -- 글로벌 통계
+  global_stats    JSONB NOT NULL DEFAULT '{
+    "total_plants_ever_grown": 0,
+    "total_plants_ever_harvested": 0,
+    "total_coins_ever_earned": 0,
+    "total_play_time_hours": 0,
+    "total_mutations_found": 0
+  }',
+
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============================================================
+-- Table: ending_history
+-- 엔딩 기록 (회차별 1개)
+-- ============================================================
+CREATE TABLE ending_history (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  session_id      UUID NOT NULL REFERENCES game_sessions(id),
+  prestige_level  INTEGER NOT NULL,
+  ending_rank     VARCHAR(1) NOT NULL,
+  difficulty      VARCHAR(10) NOT NULL DEFAULT 'normal',
+  scenario_id     VARCHAR(50) NOT NULL DEFAULT 'main',
+  final_revenue   BIGINT NOT NULL DEFAULT 0,
+  final_collection_rate NUMERIC(5,2) NOT NULL DEFAULT 0,
+  final_satisfaction    NUMERIC(5,2) NOT NULL DEFAULT 0,
+  play_duration_days    INTEGER NOT NULL DEFAULT 0,
+  completed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  UNIQUE(user_id, session_id)
+);
+
+CREATE INDEX idx_ending_history_user ON ending_history(user_id);
+
+-- ============================================================
+-- Table: plant_variants
+-- 돌연변이/희귀 품종 정의 (마스터 데이터)
+-- ============================================================
+CREATE TABLE plant_variants (
+  id              VARCHAR(50) PRIMARY KEY,   -- e.g. "rose_blue"
+  base_plant_id   VARCHAR(50) NOT NULL REFERENCES plants(id),
+  name_ko         VARCHAR(100) NOT NULL,
+  name_en         VARCHAR(100) NOT NULL,
+  variant_type    VARCHAR(20) NOT NULL,      -- 'mutation','rare','legendary'
+  rarity          VARCHAR(20) NOT NULL,      -- 'common'~'legendary'
+  trigger_config  JSONB NOT NULL,            -- MutationTrigger JSON
+  stat_modifiers  JSONB NOT NULL,            -- 성장속도/보상 배율 등
+  sprite_variant  VARCHAR(100),
+  color_tint      VARCHAR(7),               -- hex color
+  particle_effect VARCHAR(50),
+  description_ko  TEXT,
+  discovery_hint_ko TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_plant_variants_base ON plant_variants(base_plant_id);
+
+-- ============================================================
+-- Table: collection_entries
+-- 도감 엔트리 (유저 x 식물/변이 조합별 1개, 영구)
+-- ============================================================
+CREATE TABLE collection_entries (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  plant_id        VARCHAR(50) NOT NULL REFERENCES plants(id),
+  variant_id      VARCHAR(50) REFERENCES plant_variants(id),
+
+  discovery_status VARCHAR(20) NOT NULL DEFAULT 'undiscovered',
+  first_discovered_at TIMESTAMPTZ,
+  first_harvested_at  TIMESTAMPTZ,
+
+  total_grown     INTEGER NOT NULL DEFAULT 0,
+  total_harvested INTEGER NOT NULL DEFAULT 0,
+  best_health_at_harvest NUMERIC(5,2) NOT NULL DEFAULT 0,
+  best_growth_time_days  INTEGER NOT NULL DEFAULT 0,
+  total_deaths    INTEGER NOT NULL DEFAULT 0,
+
+  mastery_points  INTEGER NOT NULL DEFAULT 0,
+  mastery_level   SMALLINT NOT NULL DEFAULT 0,  -- 0~3
+
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  UNIQUE(user_id, plant_id, variant_id)
+);
+
+CREATE INDEX idx_collection_user ON collection_entries(user_id);
+CREATE INDEX idx_collection_plant ON collection_entries(plant_id);
+
+-- ============================================================
+-- Table: achievements
+-- 업적 정의 (마스터 데이터)
+-- ============================================================
+CREATE TABLE achievements (
+  id              VARCHAR(50) PRIMARY KEY,
+  category        VARCHAR(20) NOT NULL,
+  name_ko         VARCHAR(100) NOT NULL,
+  name_en         VARCHAR(100) NOT NULL,
+  description_ko  TEXT NOT NULL,
+  icon_url        VARCHAR(255),
+  rarity          VARCHAR(20) NOT NULL DEFAULT 'common',
+  condition_config JSONB NOT NULL,            -- AchievementCondition JSON
+  rewards         JSONB NOT NULL DEFAULT '{"experience": 0, "coins": 0}',
+  series_id       VARCHAR(50),
+  series_order    SMALLINT,
+  is_hidden       BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============================================================
+-- Table: user_achievements
+-- 유저별 업적 달성 기록 (영구)
+-- ============================================================
+CREATE TABLE user_achievements (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  achievement_id  VARCHAR(50) NOT NULL REFERENCES achievements(id),
+  unlocked_at     TIMESTAMPTZ,                -- NULL이면 미달성
+  unlocked_in_session UUID REFERENCES game_sessions(id),
+  progress        NUMERIC(5,4) NOT NULL DEFAULT 0, -- 0.0~1.0
+  is_notified     BOOLEAN NOT NULL DEFAULT FALSE,
+
+  UNIQUE(user_id, achievement_id)
+);
+
+CREATE INDEX idx_user_achievements_user ON user_achievements(user_id);
+
+-- ============================================================
+-- Table: titles
+-- 칭호 정의 (마스터 데이터)
+-- ============================================================
+CREATE TABLE titles (
+  id              VARCHAR(50) PRIMARY KEY,
+  name_ko         VARCHAR(100) NOT NULL,
+  name_en         VARCHAR(100) NOT NULL,
+  description_ko  TEXT,
+  category        VARCHAR(20) NOT NULL,       -- 'progression','achievement','prestige','special'
+  rarity          VARCHAR(20) NOT NULL DEFAULT 'common',
+  unlock_condition JSONB NOT NULL,
+  passive_bonus   JSONB,                      -- nullable
+  sort_order      INTEGER NOT NULL DEFAULT 0,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============================================================
+-- Table: user_titles
+-- 유저별 칭호 해금/장착 (영구)
+-- ============================================================
+CREATE TABLE user_titles (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title_id        VARCHAR(50) NOT NULL REFERENCES titles(id),
+  unlocked_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  is_equipped     BOOLEAN NOT NULL DEFAULT FALSE,
+
+  UNIQUE(user_id, title_id)
+);
+
+CREATE INDEX idx_user_titles_user ON user_titles(user_id);
+
+-- 유저당 장착 칭호 1개 보장을 위한 partial unique index
+CREATE UNIQUE INDEX idx_user_titles_equipped
+  ON user_titles(user_id) WHERE is_equipped = TRUE;
+
+-- ============================================================
+-- Table: weekly_statistics_log
+-- 주간 통계 스냅샷 (차트용 시계열)
+-- ============================================================
+CREATE TABLE weekly_statistics_log (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id      UUID NOT NULL REFERENCES game_sessions(id) ON DELETE CASCADE,
+  week_number     INTEGER NOT NULL,           -- 1~156
+  revenue_cumulative BIGINT NOT NULL DEFAULT 0,
+  revenue_weekly  INTEGER NOT NULL DEFAULT 0,
+  satisfaction    NUMERIC(5,2) NOT NULL DEFAULT 0,
+  collection_count INTEGER NOT NULL DEFAULT 0,
+  plants_active   INTEGER NOT NULL DEFAULT 0,
+  plants_harvested_weekly INTEGER NOT NULL DEFAULT 0,
+  plants_died_weekly INTEGER NOT NULL DEFAULT 0,
+  logged_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  UNIQUE(session_id, week_number)
+);
+
+CREATE INDEX idx_weekly_stats_session ON weekly_statistics_log(session_id);
+```
+
+### 8.2 Existing Table Modifications
+
+```sql
+-- user_plants 테이블에 variant_id 컬럼 추가
+ALTER TABLE user_plants
+  ADD COLUMN variant_id VARCHAR(50) REFERENCES plant_variants(id);
+
+-- game_sessions 테이블에 프레스티지 관련 컬럼 추가
+ALTER TABLE game_sessions
+  ADD COLUMN prestige_level INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN difficulty VARCHAR(10) NOT NULL DEFAULT 'normal',
+  ADD COLUMN scenario_id VARCHAR(50) NOT NULL DEFAULT 'main';
+```
+
+### 8.3 Migration Order
+
+```
+Migration 1: plant_variants (마스터 데이터, 의존성 없음)
+Migration 2: achievements, titles (마스터 데이터)
+Migration 3: prestige_profiles (users 의존)
+Migration 4: collection_entries (users, plants, plant_variants 의존)
+Migration 5: user_achievements, user_titles (users, achievements, titles 의존)
+Migration 6: ending_history (users, game_sessions 의존)
+Migration 7: weekly_statistics_log (game_sessions 의존)
+Migration 8: ALTER user_plants, game_sessions (기존 테이블 수정)
+Migration 9: Seed data (plant_variants 16종, achievements 42종, titles 20종)
+```
+
+---
+
+## 9. API Design
+
+### 9.1 Collection API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/collection | 내 도감 전체 조회 (완성도 포함) |
+| GET | /api/v1/collection/:plantId | 특정 식물 도감 상세 (마스터리, 변이 목록) |
+| GET | /api/v1/collection/stats | 도감 완성도 통계 |
+| GET | /api/v1/variants | 전체 변이종 목록 (발견된 것만, 미발견은 힌트) |
+
+### 9.2 Achievement API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/achievements | 전체 업적 목록 (달성 여부 포함) |
+| GET | /api/v1/achievements/:id | 업적 상세 |
+| GET | /api/v1/achievements/recent | 최근 달성 업적 (알림용) |
+| POST | /api/v1/achievements/:id/notify | 알림 확인 처리 |
+
+### 9.3 Title API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/titles | 내 칭호 목록 (해금/미해금 포함) |
+| POST | /api/v1/titles/:id/equip | 칭호 장착 |
+| POST | /api/v1/titles/:id/unequip | 칭호 해제 |
+
+### 9.4 Prestige API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/prestige | 프레스티지 프로필 조회 |
+| GET | /api/v1/prestige/preview | NG+ 시작 시 적용될 보너스 미리보기 |
+| POST | /api/v1/prestige/new-game-plus | NG+ 시작 (새 세션 생성) |
+| GET | /api/v1/prestige/endings | 엔딩 히스토리 |
+| GET | /api/v1/prestige/scenarios | 해금된 시나리오 목록 |
+
+### 9.5 Statistics API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/statistics/dashboard | 통계 대시보드 전체 데이터 |
+| GET | /api/v1/statistics/current-session | 현재 세션 통계 |
+| GET | /api/v1/statistics/global | 글로벌 누적 통계 |
+| GET | /api/v1/statistics/chart/:type | 특정 차트 데이터 (revenue/satisfaction/collection) |
+| GET | /api/v1/statistics/compare | 회차별 비교 데이터 |
+
+### 9.6 API Response Examples
+
+```typescript
+// GET /api/v1/collection
+{
+  "success": true,
+  "data": {
+    "completion": {
+      "base_discovered": 12,
+      "base_harvested": 9,
+      "base_mastered": 3,
+      "base_total": 15,
+      "base_completion_percent": 60.0,
+      "variant_discovered": 5,
+      "variant_total": 16,
+      "variant_completion_percent": 31.25,
+      "overall_completion_percent": 45.16
+    },
+    "entries": [
+      {
+        "plant_id": "rose",
+        "plant_name_ko": "장미",
+        "discovery_status": "mastered",
+        "mastery_level": 3,
+        "mastery_points": 280,
+        "total_harvested": 12,
+        "best_health_at_harvest": 98,
+        "variants": [
+          {
+            "variant_id": "rose_blue",
+            "name_ko": "푸른 장미",
+            "rarity": "epic",
+            "discovery_status": "discovered"
+          },
+          {
+            "variant_id": "rose_black",
+            "name_ko": "???",
+            "rarity": "legendary",
+            "discovery_status": "undiscovered",
+            "hint": "전설 속에만 존재한다는 장미..."
+          }
+        ]
+      }
+      // ... 14 more entries
+    ]
+  }
+}
+
+// POST /api/v1/prestige/new-game-plus
+{
+  "success": true,
+  "data": {
+    "new_session_id": "uuid-xxx",
+    "prestige_level": 3,
+    "difficulty": "hard",
+    "scenario_id": "scenario_b",
+    "applied_bonuses": {
+      "starting_coins": 3500,
+      "revenue_multiplier": 1.15,
+      "growth_speed_bonus": 1.10,
+      "mutation_probability_bonus": 0.06,
+      "starting_plots": 6
+    },
+    "carried_over": {
+      "achievements_count": 24,
+      "collection_entries": 21,
+      "titles_count": 8,
+      "equipped_title": "마스터 정원사"
+    }
+  }
+}
+```
+
+---
+
+## 10. System Interdependency Map
+
+### 10.1 의존성 그래프
+
+```
+                    +------------------+
+                    |   Core Systems   |
+                    | (Phase 1 + 2)    |
+                    +--------+---------+
+                             |
+            +----------------+----------------+
+            |                                 |
+   +--------v---------+           +-----------v----------+
+   | Simulation Engine |           | Scenario/Year System |
+   | (growth, health)  |           | (GameSession, KPI)   |
+   +--------+----------+           +----------+-----------+
+            |                                 |
+            +------+------+                   |
+                   |      |                   |
+          +--------v--+   |          +--------v---------+
+          | Mutation   |   |          | Prestige/NG+     |
+          | Service    |   |          | System           |
+          +-----+------+   |          +----+------+------+
+                |          |               |      |
+          +-----v------+   |         +-----v--+   |
+          | Collection  |   |         | Ending |   |
+          | (Pokedex)   |   |         | History|   |
+          +-----+-------+   |         +--------+   |
+                |           |               |       |
+          +-----v-----------v---+     +-----v-------v----+
+          | Achievement         |     | Statistics       |
+          | Evaluator           |     | Dashboard        |
+          +-----+---------------+     +------------------+
+                |
+          +-----v------+
+          | Title       |
+          | System      |
+          +-------------+
+```
+
+### 10.2 이벤트 흐름 (핵심 시나리오)
+
+#### 시나리오 A: 식물 수확 시
+
+```
+1. UserPlantController.harvest()
+   |
+2. UserPlantModel.harvest() --> DB 업데이트
+   |
+3. CollectionService.recordHarvest(userId, plantId, variantId, health)
+   |  +-- collection_entries.total_harvested++
+   |  +-- mastery_points += 20 (+ 보너스)
+   |  +-- mastery_level 재계산
+   |  +-- discovery_status 업데이트
+   |
+4. AchievementEvaluator.evaluate(userId, { type: 'plant_harvested', ... })
+   |  +-- 관련 업적 조건 체크
+   |  +-- 새로 달성된 업적 → user_achievements INSERT
+   |  +-- 칭호 연동 → TitleService.checkUnlock()
+   |
+5. GameSession.total_plants_harvested++
+   |  +-- unique_species_collected 업데이트
+   |
+6. PrestigeProfile.global_stats 업데이트
+   |
+7. Response: 수확 결과 + 업적 알림 + 도감 업데이트 + 칭호 해금 알림
+```
+
+#### 시나리오 B: NG+ 진입 시
+
+```
+1. PrestigeController.newGamePlus(userId, { difficulty, scenarioId })
+   |
+2. PrestigeService.calculateCarryover(userId)
+   |  +-- prestige_level++ 에 따른 보너스 계산
+   |  +-- 난이도 보정 적용
+   |
+3. EndingHistory.create(currentSession)
+   |  +-- 현재 세션의 최종 KPI 기록
+   |
+4. GameSessionService.create({
+   |    user_id, prestige_level, difficulty, scenario_id,
+   |    starting_coins: 1000 + carryover.starting_coins_bonus
+   |  })
+   |
+5. PrestigeProfile.update({
+   |    prestige_level++, total_playthroughs++, carryover
+   |  })
+   |
+6. AchievementEvaluator.evaluate(userId, { type: 'ng_plus_started' })
+   |
+7. TitleService.checkPrestigeTitles(userId)
+   |
+   |  [유지 항목]: collection_entries, user_achievements, user_titles, prestige_profiles
+   |  [리셋 항목]: game_session (새로 생성), user_plants (빈 상태), users.level/exp (리셋)
+   |
+8. Response: 새 세션 정보 + 적용된 보너스 + 새로 해금된 업적/칭호
+```
+
+#### 시나리오 C: 돌연변이 발생 시
+
+```
+1. SimulationService.tick() (매 시간)
+   |
+2. MutationService.checkMutation(userPlant, gameSession, envHistory)
+   |  +-- 돌연변이 후보 필터링
+   |  +-- 프레스티지 보너스 적용
+   |  +-- 마스터리 보너스 적용
+   |  +-- 확률 롤 → 성공!
+   |
+3. UserPlantModel.update({ variant_id: 'rose_blue' })
+   |
+4. CollectionService.recordDiscovery(userId, 'rose', 'rose_blue')
+   |  +-- collection_entries INSERT (variant)
+   |  +-- mastery_points += 30
+   |
+5. AchievementEvaluator.evaluate(userId, { type: 'mutation_found', variant: 'rose_blue' })
+   |
+6. WebSocket/SSE → 클라이언트 알림: "돌연변이 발견! 푸른 장미"
+```
+
+### 10.3 System Coupling Matrix
+
+| | Collection | Achievement | Title | Prestige | Statistics |
+|---|---|---|---|---|---|
+| **Collection** | - | Triggers | Unlocks | Bonus applied | Data source |
+| **Achievement** | Reads status | - | Triggers unlock | Reads level | Data source |
+| **Title** | Reads mastery | Reads unlock | - | Reads level | Data source |
+| **Prestige** | Reads rate | Triggers | Triggers | - | Data source |
+| **Statistics** | Reads all | Reads all | Reads equipped | Reads all | - |
+
+- **Triggers**: A 시스템의 이벤트가 B 시스템의 평가를 트리거
+- **Reads**: A가 B의 데이터를 읽기만 함
+- **Unlocks**: A의 조건 충족이 B의 콘텐츠를 해금
+- **Bonus applied**: A가 B로부터 계산된 보너스를 적용받음
+- **Data source**: A가 B의 데이터 시각화에 사용됨
+
+---
+
+## 11. User Experience Flow
+
+### 11.1 전체 게임 라이프사이클
+
+```
+[최초 접속]
+    |
+    v
+[회원가입/로그인]
+    |
+    v
+[메인 화면: "새 게임 시작" 버튼]
+    |
+    v
+[Tutorial 시나리오]  ←-- 칭호 부여: "새싹 정원사"
+    |
+    v
+[Year 1~3 게임플레이]
+    |   +-- 수확 시 → 도감 업데이트 + 업적 체크 + 마스터리 적립
+    |   +-- 돌연변이 → 알림 팝업 + 도감 신규 엔트리
+    |   +-- 레벨업 시 → 칭호 진급 체크
+    |   +-- 매 주 → 통계 스냅샷 기록
+    |
+    v
+[Final Evaluation → 엔딩 (S/A/B/C/F)]
+    |
+    v
+[Credits → 업적 체크 (엔딩 관련)]
+    |
+    v
+[Post-Game 선택 화면]
+    |
+    +-- [Continue] → 샌드박스 모드 (시간 제한 없음)
+    |
+    +-- [New Game+] → NG+ 설정 화면
+            |
+            +-- 난이도 선택 (해금된 것만)
+            +-- 시나리오 선택 (해금된 것만)
+            +-- 캐리오버 보너스 확인
+            +-- "시작" 클릭
+                |
+                v
+            [새 GameSession (prestige_level + 1)]
+                |
+                v
+            [Year 1 Spring, 보너스 적용 상태]
+                |
+                v
+            [반복... 더 높은 엔딩, 더 많은 도감/업적 달성]
+```
+
+### 11.2 핵심 UX Moments
+
+| 순간 | 감정 목표 | UI 표현 |
+|------|----------|---------|
+| 첫 수확 | 성취감 | 축하 애니메이션 + 업적 배지 팝업 |
+| 돌연변이 발견 | 놀라움, 흥분 | 풀스크린 발견 연출 + 도감 등록 애니메이션 |
+| 칭호 진급 | 자부심 | 칭호 카드 플립 연출 + "축하합니다" 모달 |
+| NG+ 시작 | 기대감 | 보너스 적용 카운터 애니메이션 + "강화된 시작" 연출 |
+| 도감 완성 | 대단한 성취 | 특별 엔딩 크레딧 + Legendary 칭호 부여 |
+| S랭크 달성 | 최고의 달성감 | 특별 엔딩 씬 + 불꽃놀이 + 특별 칭호 |
+
+### 11.3 알림 시스템
+
+```typescript
+interface Notification {
+  type: 'achievement' | 'mutation' | 'title' | 'mastery' | 'collection';
+  priority: 'low' | 'medium' | 'high' | 'critical';
+  display: 'toast' | 'modal' | 'fullscreen';
+  data: any;
+  auto_dismiss_ms: number;           // 0이면 수동 닫기
+}
+
+// 우선순위별 표시 방식
+// critical (fullscreen): 전설 변이 발견, S랭크 달성, 도감 완성
+// high (modal): 업적 달성, 칭호 해금, Legendary/Epic 변이 발견
+// medium (toast 5초): 마스터리 레벨업, 일반 업적
+// low (toast 3초): 도감 상태 변경, 통계 마일스톤
+```
+
+---
+
+## 12. Frontend Architecture
+
+### 12.1 New Pages
+
+| 페이지 | 경로 | 설명 |
+|--------|------|------|
+| CollectionPage (개선) | /collection | 도감 메인 (그리드 뷰 + 완성도 바) |
+| CollectionDetailPage | /collection/:plantId | 식물 상세 + 마스터리 + 변이 목록 |
+| AchievementsPage | /achievements | 업적 목록 (카테고리 탭 + 진행도) |
+| TitlesPage | /titles | 칭호 목록 + 장착 관리 |
+| StatisticsPage | /statistics | 통계 대시보드 |
+| PrestigePage | /prestige | NG+ 설정 + 보너스 미리보기 |
+| PostGamePage | /post-game | 엔딩 후 선택 화면 |
+
+### 12.2 New Components
+
+```
+components/
+  collection/
+    CollectionGrid.tsx          // 도감 그리드 (15종 + 변이)
+    CollectionCard.tsx          // 개별 식물 카드 (상태별 렌더링)
+    MasteryProgress.tsx         // 마스터리 진행도 바
+    VariantBadge.tsx            // 변이종 배지
+    CollectionCompletion.tsx    // 완성도 프로그레스 바
+
+  achievements/
+    AchievementList.tsx         // 업적 목록
+    AchievementCard.tsx         // 개별 업적 카드
+    AchievementProgress.tsx     // 진행도 표시
+    AchievementPopup.tsx        // 달성 시 팝업
+
+  titles/
+    TitleList.tsx               // 칭호 목록
+    TitleCard.tsx               // 칭호 카드 + 장착 버튼
+    TitleBadge.tsx              // 프로필에 표시되는 칭호 배지
+    EquippedTitle.tsx           // 현재 장착 칭호 표시
+
+  statistics/
+    StatsDashboard.tsx          // 대시보드 레이아웃
+    RevenueChart.tsx            // 매출 라인 차트
+    SatisfactionChart.tsx       // 만족도 차트
+    CollectionChart.tsx         // 수집 추이 차트
+    MasteryOverview.tsx         // 종별 마스터리 바 차트
+    EndingTimeline.tsx          // 엔딩 히스토리 타임라인
+    AchievementDonut.tsx        // 업적 달성률 도넛
+    SessionComparison.tsx       // 회차별 비교 차트
+
+  prestige/
+    PrestigeSetup.tsx           // NG+ 설정 폼
+    BonusPreview.tsx            // 적용될 보너스 미리보기
+    DifficultySelector.tsx      // 난이도 선택
+    ScenarioSelector.tsx        // 시나리오 선택
+    CarryoverSummary.tsx        // 유지/리셋 항목 요약
+
+  notifications/
+    NotificationManager.tsx     // 알림 큐 관리
+    AchievementToast.tsx        // 업적 토스트
+    MutationDiscovery.tsx       // 돌연변이 발견 풀스크린
+    TitleUnlock.tsx             // 칭호 해금 모달
+```
+
+### 12.3 Chart Library
+
+- **Recharts** (React 네이티브 차트 라이브러리) 사용 권장
+  - 이미 React + TypeScript 환경
+  - SSR 불필요 (SPA)
+  - 라인/바/도넛/스텝 차트 모두 지원
+  - Tailwind CSS와 호환
+
+---
+
+## 13. Implementation Roadmap
+
+### Phase MVP (4~5 weeks)
+
+> 핵심 루프가 돌아가는 최소 구현
+
+| 주차 | 작업 | 산출물 |
+|------|------|--------|
+| 1 | DB 마이그레이션 (Migration 1~8) | 모든 신규 테이블 생성 |
+| 1 | Seed 데이터: plant_variants 16종, achievements 42종, titles 20종 | Migration 9 |
+| 2 | Backend: CollectionService, CollectionController | 도감 CRUD API |
+| 2 | Backend: MutationService (시뮬레이션 틱 통합) | 돌연변이 발생 로직 |
+| 3 | Backend: AchievementEvaluator, AchievementController | 업적 평가/조회 API |
+| 3 | Backend: TitleService, TitleController | 칭호 해금/장착 API |
+| 4 | Frontend: CollectionPage 개선, AchievementsPage | UI 구현 |
+| 4 | Frontend: NotificationManager (Toast 기반) | 알림 기본 구현 |
+| 5 | Integration testing | 수확→도감→업적→칭호 흐름 E2E 테스트 |
+
+### Phase 2 (3~4 weeks)
+
+> 프레스티지 시스템 + 통계 대시보드
+
+| 주차 | 작업 | 산출물 |
+|------|------|--------|
+| 6 | Backend: PrestigeService, PrestigeController | NG+ API |
+| 6 | Backend: 엔딩 히스토리 기록 로직 | 엔딩→NG+ 전환 흐름 |
+| 7 | Backend: weekly_statistics_log 기록 (시뮬레이션 틱 통합) | 주간 스냅샷 |
+| 7 | Backend: StatisticsService, StatisticsController | 통계 집계 API |
+| 8 | Frontend: PrestigePage, PostGamePage | NG+ UI |
+| 8 | Frontend: StatisticsPage (Recharts 통합) | 통계 대시보드 UI |
+| 9 | Frontend: 풀스크린 돌연변이 발견, 칭호 해금 모달 | 고품질 UX |
+| 9 | 밸런스 테스팅 + 보너스 수치 조정 | 프레스티지 밸런스 |
+
+### Phase 3 - Extension (2~3 weeks)
+
+> 해금 시나리오, 난이도 모드, 폴리싱
+
+| 주차 | 작업 | 산출물 |
+|------|------|--------|
+| 10 | 해금 시나리오 콘텐츠 구현 (scenario_b, scenario_c) | 시나리오 데이터 + 조건부 로직 |
+| 10 | Hard/Extreme 난이도 모드 밸런스 | 난이도 배율 조정 |
+| 11 | 숨김 업적 구현 + 시크릿 발견 연출 | 히든 콘텐츠 |
+| 11 | Legendary 시나리오 + Zen 가든 모드 | 특별 시나리오 |
+| 12 | 전체 E2E 테스트 + 성능 최적화 | QA 완료 |
+| 12 | 변이종 스프라이트 에셋 + 시각 이펙트 | 비주얼 폴리싱 |
+
+---
+
+## 14. Technical Considerations & Risks
+
+### 14.1 Performance
+
+| 우려 사항 | 대응 전략 |
+|----------|----------|
+| 업적 평가 오버헤드 (매 이벤트마다) | 이벤트-업적 매핑 테이블로 후보 축소, 이미 달성된 업적 즉시 스킵 |
+| 돌연변이 확률 체크 (매 시뮬레이션 틱) | variant_id가 이미 있으면 스킵, eligible variants 캐싱 |
+| 통계 대시보드 집계 쿼리 | weekly_statistics_log로 사전 집계, 5분 캐시, Lazy Loading |
+| 도감 페이지 로딩 (31종 + 마스터리 데이터) | 페이지네이션 불필요 (31건), 단일 집계 쿼리 최적화 |
+
+### 14.2 Data Integrity
+
+| 우려 사항 | 대응 전략 |
+|----------|----------|
+| NG+ 시 리셋/유지 항목 혼동 | 명확한 트랜잭션: 새 세션 생성 → 유저 레벨 리셋 → prestige 업데이트를 atomic 처리 |
+| 업적 중복 달성 방지 | UNIQUE(user_id, achievement_id) + unlocked_at NULL 체크 |
+| 칭호 동시 장착 방지 | Partial Unique Index + 서비스 레이어 validation |
+| 돌연변이 발생 후 서버 크래시 | 트랜잭션: variant_id 업데이트 + collection_entry 생성을 atomic |
+| 매주 통계 스냅샷 누락 | UNIQUE(session_id, week_number) + 누락 감지 & 백필 로직 |
+
+### 14.3 Scalability
+
+| 우려 사항 | 대응 전략 |
+|----------|----------|
+| collection_entries 테이블 크기 (유저 × 31종) | 유저당 최대 31행, 인덱스 충분 |
+| user_achievements 테이블 크기 (유저 × 42업적) | 유저당 최대 42행, 인덱스 충분 |
+| weekly_statistics_log (유저 × 회차 × 156주) | 파티셔닝 고려 (session_id 기준), 오래된 데이터 아카이브 |
+| 동시 다수 유저 시뮬레이션 틱 | 돌연변이/업적 체크는 비동기 큐로 분리 가능 |
+
+### 14.4 Backward Compatibility
+
+| 항목 | 전략 |
+|------|------|
+| 기존 user_plants 데이터 | variant_id 컬럼 nullable, 기존 데이터는 NULL (기본종) |
+| 기존 game_sessions | prestige_level 기본값 0, difficulty 기본값 'normal' |
+| 기존 users | prestige_profiles 자동 생성 (첫 접근 시 또는 마이그레이션 시 bulk insert) |
+| 기존 Collection.tsx | 확장 (breaking change 최소화), 기존 API 유지 + 신규 API 추가 |
+
+### 14.5 Testing Strategy
+
+| 테스트 유형 | 범위 | 도구 |
+|-----------|------|------|
+| Unit | MutationService, AchievementEvaluator, PrestigeService | Jest |
+| Integration | 수확→도감→업적→칭호 전체 흐름 | Jest + Supertest |
+| E2E | NG+ 전체 사이클 (엔딩→설정→시작→보너스 확인) | Playwright |
+| Balance | 프레스티지 보너스 누적이 게임을 파괴하지 않는지 | 수동 + 시뮬레이션 스크립트 |
+
+### 14.6 Open Questions
+
+| # | 질문 | 의사결정 필요 시점 |
+|---|------|-----------------|
+| 1 | 변이종 스프라이트 에셋을 어떻게 제작하는가? (color_tint fallback vs 전용 에셋) | Phase MVP 시작 전 |
+| 2 | 통계 대시보드를 실시간(WebSocket)으로 할 것인가, 폴링으로 할 것인가? | Phase 2 시작 전 |
+| 3 | 프레스티지 보너스 상한값의 최종 밸런스 수치 | Phase 2 밸런스 테스팅 |
+| 4 | 해금 시나리오의 콘텐츠 깊이 (시나리오별 고유 이벤트/NPC 필요?) | Phase 3 시작 전 |
+| 5 | 소셜 기능(리더보드, 정원 방문) 추가 시 칭호/통계 공유 범위 | 향후 Phase |
+
+---
+
+## Appendix A: Glossary
+
+| 용어 | 정의 |
+|------|------|
+| Prestige Level | NG+ 시작 횟수. 0이면 첫 회차 |
+| Mastery | 특정 식물 종에 대한 숙련도. Bronze/Silver/Gold 3단계 |
+| Carryover | NG+ 시작 시 이전 회차에서 이월되는 보너스 |
+| Variant | 기본종에서 파생된 돌연변이/희귀 품종 |
+| Discovery Status | 도감 엔트리의 발견 상태 (미발견→실루엣→발견→마스터) |
+| Hard Cap | 프레스티지 보너스 누적의 최대 상한값 |
+
+## Appendix B: File Structure (Proposed)
+
+```
+backend/src/
+  services/
+    collection.service.ts        # NEW - 도감 비즈니스 로직
+    mutation.service.ts          # NEW - 돌연변이 발생 로직
+    achievement.service.ts       # NEW - 업적 평가 엔진
+    title.service.ts             # NEW - 칭호 해금/장착
+    prestige.service.ts          # NEW - 프레스티지/NG+ 관리
+    statistics.service.ts        # NEW - 통계 집계
+    simulation.service.ts        # MODIFIED - mutation tick 추가
+
+  controllers/
+    collection.controller.ts     # NEW
+    achievement.controller.ts    # NEW
+    title.controller.ts          # NEW
+    prestige.controller.ts       # NEW
+    statistics.controller.ts     # NEW
+
+  models/
+    PlantVariant.ts              # NEW
+    CollectionEntry.ts           # NEW
+    Achievement.ts               # NEW
+    UserAchievement.ts           # NEW
+    Title.ts                     # NEW
+    UserTitle.ts                 # NEW
+    PrestigeProfile.ts           # NEW
+    EndingHistory.ts             # NEW
+    WeeklyStatisticsLog.ts       # NEW
+
+  routes/
+    collection.routes.ts         # NEW
+    achievement.routes.ts        # NEW
+    title.routes.ts              # NEW
+    prestige.routes.ts           # NEW
+    statistics.routes.ts         # NEW
+
+  migrations/
+    YYYYMMDD_01_plant_variants.ts
+    YYYYMMDD_02_achievements_titles.ts
+    YYYYMMDD_03_prestige_profiles.ts
+    YYYYMMDD_04_collection_entries.ts
+    YYYYMMDD_05_user_achievements_titles.ts
+    YYYYMMDD_06_ending_history.ts
+    YYYYMMDD_07_weekly_statistics_log.ts
+    YYYYMMDD_08_alter_existing_tables.ts
+    YYYYMMDD_09_seed_master_data.ts
+
+frontend/src/
+  pages/
+    Collection.tsx               # MODIFIED (대폭 확장)
+    CollectionDetail.tsx         # NEW
+    Achievements.tsx             # NEW
+    Titles.tsx                   # NEW
+    Statistics.tsx               # NEW
+    Prestige.tsx                 # NEW
+    PostGame.tsx                 # NEW
+
+  components/
+    collection/                  # NEW directory
+    achievements/                # NEW directory
+    titles/                      # NEW directory
+    statistics/                  # NEW directory
+    prestige/                    # NEW directory
+    notifications/               # NEW directory
+
+  services/
+    collection.service.ts        # NEW
+    achievement.service.ts       # NEW
+    title.service.ts             # NEW
+    prestige.service.ts          # NEW
+    statistics.service.ts        # NEW
+
+  store/
+    collectionSlice.ts           # NEW (Redux Toolkit)
+    achievementSlice.ts          # NEW
+    titleSlice.ts                # NEW
+    prestigeSlice.ts             # NEW
+    statisticsSlice.ts           # NEW
+    notificationSlice.ts         # NEW
+```
+
+---
+
+*End of Document*

--- a/docs/MILESTONE_EVENT_NPC_REVIEW.md
+++ b/docs/MILESTONE_EVENT_NPC_REVIEW.md
@@ -1,0 +1,549 @@
+# Plantii Phase 3 - Milestone Review Report
+# Event & NPC System - Design Specification Review
+
+> **Reviewer**: AI Architect
+> **Review Date**: 2026-04-24
+> **Document Under Review**: `docs/MILESTONE_EVENT_NPC_SYSTEM.md` v1.0
+> **Status**: CONDITIONAL APPROVAL (with required fixes)
+
+---
+
+## 1. Executive Summary
+
+Phase 3 이벤트 & NPC 시스템 설계 명세서는 **전반적으로 높은 완성도(82/100)**를 보인다. 계절 사이클, 랜덤 이벤트, NPC 퀘스트, 친밀도, 시즌 컨테스트의 5개 핵심 서브시스템이 체계적으로 정의되어 있으며, 알고리즘과 데이터 구조가 구현 가능한 수준으로 구체화되어 있다. 그러나 **7가지 핵심 개선사항**과 **4가지 기술적 리스크**가 식별되었으며, 이를 반영한 후 구현에 착수해야 한다.
+
+### Overall Score: 82/100
+
+| Category | Score | Verdict |
+|----------|-------|---------|
+| (1) 요구사항 완전성 | 85/100 | PASS - 마일스톤 요소 대부분 충족, 일부 누락 |
+| (2) 게임플레이 다양성 | 80/100 | CONDITIONAL - 전략 차이 구현 가능하나 보강 필요 |
+| (3) 기술적 실행 가능성 | 83/100 | CONDITIONAL - 알고리즘 합리적, 오프라인 처리 미확정 |
+| (4) 시스템 간 일관성 | 78/100 | CONDITIONAL - 인터페이스 불명확 지점 존재 |
+| (5) 리스크 식별 | 82/100 | PASS - 주요 리스크 식별, 일부 누락 |
+
+---
+
+## 2. Detailed Review: (1) 요구사항 완전성 - 85/100
+
+### 2.1 Strengths (강점)
+
+**A. 계절 사이클이 정밀하게 정의되어 있다.**
+
+- 120일 연간 사이클이 현실적이며, 현실 1일 = 게임 1일 매핑이 직관적
+- 6개 식물 카테고리 x 4개 계절 x 3개 보정 계수(growth/yield/quality) = 72개 보정값이 모두 구체적으로 제시됨
+- 계절 전환 블렌드 메커니즘(마지막 3일 보간)이 자연스러운 전환을 보장
+- 겨울 휴면, 봄 개화 부스트, 여름 폭풍 취약 등 계절별 특수 행동이 잘 정의됨
+
+**B. 랜덤 이벤트 시스템의 확률 설계가 게임 디자인 관점에서 우수하다.**
+
+- Pity System(연속 미발생 보정)이 "너무 오랫동안 아무 일도 안 일어남" 문제를 방지
+- 쿨다운 + 동시 이벤트 제한(최대 3개)이 이벤트 스팸을 방지
+- 이벤트 타입별 계절 가중치가 thematic coherence를 제공 (여름 해충, 가을 폭풍 등)
+
+**C. NPC 시스템이 풍부한 개성과 성장 곡선을 제공한다.**
+
+- 8명의 NPC가 5가지 성격 타입으로 분류되어 고유한 퀘스트 패턴 생성
+- 6단계 친밀도 시스템과 NPC별 Max Affinity 특별 보상이 장기 목표 제공
+- 퀘스트 생성 알고리즘이 NPC 성격 + 유저 레벨을 반영하여 동적으로 퀘스트를 생성
+
+### 2.2 Issues (개선 필요)
+
+**ISSUE-1: Disease(질병) 이벤트의 상세 설계가 누락됨**
+
+Section 3.1에서 `EventCategory`에 `DISEASE = 'disease'`를 정의하고, 확률 매트릭스(Section 3.2)와 가중치(Section 7.2)에도 포함시켰지만, Pest(3.3), Storm(3.4), Lucky Rain(3.5), Rare Seed(3.6)와 같은 **상세 인터페이스/효과/대응 수단 정의가 없다**. 5개 이벤트 타입 중 Disease만 빠져 있다.
+
+```
+// 존재하는 이벤트 상세 설계:
+- 3.3 PestEvent       (interface + 해충 5종 + 피해 계산 공식)
+- 3.4 StormEvent       (interface + 폭풍 4종 + 피해 계산 공식)
+- 3.5 LuckyRainEvent   (interface + 3 tier + 무지개 보너스)
+- 3.6 RareSeedEvent    (interface + 8종 씨앗 + 드롭 테이블)
+// 누락:
+- Disease Event        (interface 없음, 증상/전파/치료 미정의)
+```
+
+> **Required Action**: `DiseaseEvent` 인터페이스 추가. 최소 다음을 정의해야 함:
+> - 질병 종류 (곰팡이병, 바이러스, 세균성 질병 등)
+> - 카테고리별 취약도 매트릭스
+> - 전파 메커니즘 (Pest의 spread_chance와 유사하되 차별화)
+> - 치료 수단 및 비용
+> - Pest와의 차별점 명확화 (Pest = 외부 공격, Disease = 내부 감염)
+
+**ISSUE-2: Visitor 이벤트 카테고리가 정의만 되고 사용되지 않음**
+
+`EventCategory.VISITOR = 'visitor'`가 선언되었으나:
+- 확률 매트릭스(Section 3.2)에 포함되지 않음
+- `SEASON_WEIGHTS` 테이블(Section 7.2)에 포함되지 않음
+- `SEVERITY_WEIGHTS` 테이블에 포함되지 않음
+- 상세 설계 섹션이 없음
+
+NPC 방문과의 관계가 불명확하다. NPC 방문 확률은 별도 알고리즘(Section 4.3)으로 관리되는데, VISITOR 이벤트와 중복되는지, 특별 방문자(NPC 이외)인지 구분이 안 된다.
+
+> **Required Action**: 다음 중 하나를 선택:
+> - **(A)** VISITOR를 `EventCategory`에서 제거하고, NPC 방문은 NPC 시스템이 독립적으로 관리
+> - **(B)** VISITOR를 "특별 방문자" (NPC 시스템 밖의 일회성 상인, 여행자 등)로 정의하고 상세 설계 추가
+> - **권장: (A)** - NPC 방문과 Event가 별도 시스템이라면 혼란을 줄이기 위해 제거
+
+**ISSUE-3: Herb Contest와 Rare Exhibit의 심사 기준이 누락됨**
+
+Section 5.2에서 Flower Show, Section 5.3에서 Harvest Festival의 심사 기준이 상세히 정의되었지만, Section 5.4의 연간 캘린더에 나열된 **Herb Contest(여름)**와 **Rare Exhibit(겨울)**의 심사 기준, 출품 규칙, 상품이 정의되지 않았다.
+
+```
+// 상세 심사 기준이 있는 컨테스트:
+- Flower Show       (Section 5.2 - 5개 심사 기준 + 가중치 + NPC 점수 생성)
+- Harvest Festival  (Section 5.3 - 4개 심사 기준 + 가중치 + 상품)
+// 누락:
+- Herb Contest      (참가 조건만 Section 5.4에 있음)
+- Rare Exhibit      (참가 조건만 Section 5.4에 있음)
+```
+
+> **Required Action**: Herb Contest와 Rare Exhibit의 심사 기준, 점수 알고리즘, 상품 테이블 추가. 또는 Phase 3 초기 릴리스에서 Flower Show + Harvest Festival만 구현하고, 나머지 2개는 Phase 3.5로 연기하되 스케줄에 명시.
+
+---
+
+## 3. Detailed Review: (2) 게임플레이 다양성 - 80/100
+
+### 3.1 "플레이할 때마다 다른 이벤트 조합" 구현 가능성 평가
+
+**PASS - 다양성 확보 메커니즘이 충분하다.**
+
+| Randomization Source | Mechanism | Effectiveness |
+|---------------------|-----------|--------------|
+| 이벤트 발생 여부 | 확률 기반 (base * season * pity * level * garden) | HIGH - 5개 변수 조합 |
+| 이벤트 심각도 | 가중 랜덤 (SEVERITY_WEIGHTS) | MEDIUM - 예측 가능한 분포 |
+| 해충 종류 | 5종 x 계절 피크 | MEDIUM |
+| 희귀 씨앗 종류 | 8종 x 레벨/계절 보정 | HIGH |
+| NPC 방문 순서 | 확률 기반 + 조건부 | HIGH |
+| 퀘스트 내용 | NPC 성격 x 난이도 x 식물 조합 | HIGH |
+| 컨테스트 결과 | NPC 경쟁자 점수 분산 | MEDIUM |
+
+**시뮬레이션 추정**: 30일 플레이 기준, 이벤트 조합 경우의 수:
+- 이벤트 발생: ~8-12회 (5종 x 평균 확률)
+- 각 이벤트의 심각도: 4단계
+- NPC 방문: ~15-25회
+- 퀘스트: ~8-15개
+- **총 경험 조합**: 사실상 무한대 (확률적 독립 이벤트 체인)
+
+### 3.2 "계절별 전략 차이" 구현 가능성 평가
+
+**CONDITIONAL - 전략 차이는 존재하나, 최적 전략이 명확해 전략적 깊이가 제한됨.**
+
+| Season | Dominant Strategy | Strategic Depth |
+|--------|------------------|----------------|
+| Spring | 허브/꽃 집중 재배 (growth 1.3-1.4x) + 꽃 품평회 준비 | LOW - 최적해가 명확 |
+| Summer | 과일 집중 (growth 1.4x, yield 1.5x) + 해충 대비 | MEDIUM - 해충 리스크 관리 필요 |
+| Autumn | 수확 축제용 다양성 확보 + 엽채류 품질 챙기기 | HIGH - 다양성 vs 집중의 트레이드오프 |
+| Winter | 다육류/관엽류 유지 + 희귀 식물 전시 준비 | LOW - 할 수 있는 게 제한적 |
+
+**ISSUE-4: 겨울 시즌이 "대기 시간"에 불과할 위험**
+
+겨울의 growth modifier가 대부분 0.1-0.6으로 극히 낮아, 30일간 "성장이 거의 안 되는 시즌"이 된다. 플레이어가 겨울 30일(현실 30일) 동안 할 수 있는 의미 있는 행동이 부족하다:
+
+```
+겨울 보정 최고치: succulent growth 0.6, foliage growth 0.5
+겨울 이벤트 확률: pest 0.02, storm 0.10, lucky_rain 0.03, rare_seed 0.01
+  -> 모든 이벤트가 최저치. 폭풍만 0.10으로 의미 있음.
+
+겨울 NPC: 특별 언급 없음
+겨울 컨테스트: Rare Exhibit (Day 25-27) - 상세 미정의 (ISSUE-3)
+```
+
+현실 30일 동안 게임에서 할 것이 없으면 유저 이탈의 핵심 원인이 된다.
+
+> **Required Action**: 겨울 시즌 콘텐츠 보강. 다음 중 복수 적용 권장:
+> - **(A)** 겨울 전용 실내 재배 시스템 (온실 연동 - Phase 2 greenhouse와 연계)
+> - **(B)** 겨울 전용 NPC 이벤트 (크리스마스 마켓, 설날 특별 퀘스트 등)
+> - **(C)** 겨울 휴면 식물의 "관리 미니게임" (보온재 설치, 동해 방지 등)
+> - **(D)** 겨울 희귀 식물 전시 컨테스트 상세화 + 보상 강화
+> - **(E)** 일부 식물 카테고리의 겨울 성장률 상향 (succulent 0.6 -> 0.8, foliage 0.5 -> 0.7)
+
+**ISSUE-5: 이벤트 대응이 "코인만 쓰면 해결"로 단순화될 위험**
+
+Pest Event 대응 (Section 3.3)을 보면:
+
+```
+MINOR:    50 coins (살충제)
+MODERATE: 150 coins
+MAJOR:    400 coins
+CRITICAL: 800 coins + 특수 아이템
+```
+
+Storm Event에는 대응 수단 자체가 정의되지 않았다 (shelter_protection만 언급). Lucky Rain과 Rare Seed는 긍정적 이벤트라 대응이 불필요. Disease는 미정의.
+
+결국 부정적 이벤트 대응 = "코인 지불"이라는 단순한 메커니즘 하나뿐이다. 이는 Phase 2의 "경영 판단" 요소를 약화시킨다.
+
+> **Recommendation**: 이벤트 대응에 전략적 선택지 추가:
+> - 살충제 즉시 사용 (코인 비용 높음, 즉시 해결) vs 자연 치유 대기 (비용 없음, 피해 지속)
+> - 특정 식물 격리 (해당 식물 성장 중단, 전파 방지) vs 전체 치료 (비용 높음, 전체 회복)
+> - 예방 조치 아이템 (사전 구매하여 이벤트 발생 시 자동 적용)
+
+---
+
+## 4. Detailed Review: (3) 기술적 실행 가능성 - 83/100
+
+### 4.1 알고리즘 합리성 평가
+
+**A. 이벤트 스케줄링 알고리즘 (Section 7.1) - GOOD**
+
+```typescript
+// 일일 처리 플로우가 명확하고 구현 가능:
+// 1. 계절/일차 조회 -> 2. 만료 이벤트 정리 -> 3. 동시 제한 체크
+// 4. 쿨다운 체크 -> 5. 확률 계산 -> 6. 이벤트 생성 -> 7. 효과 적용
+```
+
+- `processDailyEvents()` 의사코드가 구현체 수준으로 구체적
+- `MAX_CONCURRENT_EVENTS = 3` 안전장치 적절
+- 쿨다운 시스템이 이벤트 스팸 방지에 효과적
+- Pity Factor의 상한(2.0)이 확률 폭주를 방지
+
+**그러나 한 가지 문제**: 이벤트 타입 순회 순서가 결과에 영향을 미친다.
+
+```typescript
+for (const eventType of EVENT_TYPES) {  // 순서가 고정되면 pest가 항상 먼저 판정
+  // ... 확률 계산 및 이벤트 생성
+  if (activeEvents.length + newEvents.length >= MAX_CONCURRENT_EVENTS) break;
+}
+```
+
+`EVENT_TYPES` 배열의 순서가 고정이면, 동시 이벤트 제한(3개)에 걸릴 때 뒤쪽 이벤트 타입(rare_seed 등)이 불리해진다.
+
+> **Required Action**: EVENT_TYPES 순회 전 `shuffle(EVENT_TYPES)` 추가하여 공정한 판정 보장
+
+**B. NPC 방문 확률 알고리즘 (Section 4.3) - GOOD**
+
+- 조건 미충족 시 `return 0`으로 즉시 차단하는 설계가 효율적
+- 친밀도/선호식물/계절의 복합 보정이 의미 있는 방문 패턴 생성
+- `min(... , 0.95)` 상한이 100% 확정 방문을 방지
+
+**C. 퀘스트 생성 알고리즘 (Section 4.4) - GOOD with concerns**
+
+- NPC 성격 기반 가중치 랜덤 선택이 다양한 퀘스트 생성에 효과적
+- 난이도별 파라미터 테이블이 명확
+
+**그러나 실현 불가능 퀘스트 생성 위험이 있다** (문서 Risk 12.1에서도 언급):
+
+```
+예시: 셰프 이준 (PICKY, herb+fruit, A+ quality) 이
+       레벨 5 유저에게 "hard" 퀘스트를 발행:
+       "A등급 이상 토마토 5개를 3일 내 납품"
+
+       문제: 토마토 성장 최소 30일. 3일 내 A등급 5개는 불가능.
+```
+
+> **Required Action**: 퀘스트 생성 시 **유저 보유 식물 상태 체크** 로직 추가:
+> ```
+> // 납품(DELIVER) 퀘스트: 유저가 수확 가능 또는 곧 수확 가능한 식물 기반
+> // 재배(GROW) 퀘스트: deadline >= 해당 식물의 최소 성장일
+> // 품질(QUALITY) 퀘스트: 유저 레벨에서 달성 가능한 품질 등급 기반
+> ```
+
+**D. 컨테스트 NPC 점수 생성 (Section 5.2) - ACCEPTABLE but fragile**
+
+```
+base = 40 + userLevel * 2.5
+scores = [base + random(-15, +15)] * 4
+```
+
+레벨 1: base = 42.5, range = 27.5-57.5
+레벨 15: base = 77.5, range = 62.5-92.5
+
+이 공식은 작동하지만, 유저가 항상 적정 품질의 꽃만 출품하면 NPC보다 쉽게 이길 수 있다. 역으로 유저의 꽃이 NPC의 최고 점수보다 낮으면 이길 수 없어 참가 동기가 없다.
+
+> **Recommendation**: NPC 점수 생성에 "유저 제출 점수 참조" 로직 추가. 예: NPC 최고 점수 = `min(userScore + random(5, 15), 98)` 형태로, 유저가 잘하면 NPC도 강해지는 적응형 난이도.
+
+### 4.2 기술적 실행 가능성 핵심 리스크
+
+**ISSUE-6: 오프라인 이벤트 처리 전략이 미확정**
+
+Section 12.2.1에서 "로그인 시 미처리 일수만큼 일괄 처리 (최대 7일치)"를 제안했지만, 이것이 **"제안"** 수준에 머물러 있다. 이는 구현의 핵심 아키텍처 결정이다.
+
+```
+시나리오: 유저가 14일간 미접속 후 로그인
+  - 7일치 이벤트 일괄 처리 시, 최악의 경우:
+    - 7개의 해충 이벤트 (각 쿨다운 3일이므로 최대 2-3개)
+    - 7개의 폭풍 이벤트 (쿨다운 2일이므로 최대 3-4개)
+    - 식물 건강도 0으로 전멸 가능
+  - 결과: 오랜만에 접속한 유저가 "밭이 폐허"가 되어 이탈
+
+  vs.
+
+  - 7일치를 한 번에 로딩하면 API 응답 시간 문제
+  - JSONB payload가 큰 이벤트 7-21개를 한 번에 생성
+```
+
+> **Required Action**: 오프라인 처리 전략을 확정하고 문서에 반영:
+> - 일괄 처리 일수 상한 결정 (7일 권장)
+> - 오프라인 기간 중 부정적 이벤트 피해 감쇠 계수 도입 (예: `offline_damage_factor = 0.5`)
+> - "오프라인 보호막" 아이템/메커니즘 고려 (친밀도 높은 NPC가 대신 관리)
+> - 로그인 시 일괄 처리 API의 응답 시간 상한 설정 (예: 3초)
+
+**ISSUE-7: `game_season` 테이블의 서버 전역 상태 동기화**
+
+Section 6.1에서 `GlobalSeasonState`를 "서버 전역 상태 (모든 유저 공유)"로 정의했다. 그러나:
+
+```sql
+CREATE TABLE game_season (
+  id SERIAL PRIMARY KEY,
+  game_start_date TIMESTAMP NOT NULL DEFAULT NOW(),
+  current_tick INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+```
+
+- `current_tick`은 누가 업데이트하는가? `simulationCron`이 매일 +1?
+- 서버가 여러 대(horizontal scaling) 일 때, 여러 cron이 동시에 tick을 올릴 수 있음
+- `game_start_date`가 서버 재시작 시 리셋되면 안 됨 (DEFAULT NOW()가 위험)
+
+> **Required Action**:
+> - `game_start_date`의 DEFAULT NOW()를 제거하고, 최초 1회 수동 설정하는 migration seed로 변경
+> - `current_tick` 업데이트를 `SELECT ... FOR UPDATE` + 트랜잭션으로 보호
+> - 또는 `current_tick`을 저장하지 않고 `game_start_date`로부터 매번 계산하는 stateless 방식 채택 (권장)
+>
+> ```typescript
+> // 권장: Stateless 방식
+> function getCurrentGameDay(): number {
+>   const startDate = getGameStartDate(); // DB에서 1회 조회, 캐싱
+>   return Math.floor((Date.now() - startDate.getTime()) / (24 * 60 * 60 * 1000));
+> }
+> ```
+
+---
+
+## 5. Detailed Review: (4) 시스템 간 일관성 - 78/100
+
+### 5.1 NPC 퀘스트 <-> 친밀도 인터페이스
+
+**PASS - 잘 연결되어 있다.**
+
+```
+퀘스트 완료 -> affinity +5~15 (난이도별)
+퀘스트 실패 -> affinity -5
+친밀도 레벨 UP -> 퀘스트 보상 +10%~50%
+친밀도 80+ -> 전설 퀘스트 해금
+친밀도 100 -> 영구 특별 보상
+```
+
+이 순환이 자기 강화 루프(virtuous cycle)를 형성하여 장기 플레이 동기를 제공한다.
+
+### 5.2 시즌 컨테스트 <-> NPC 시스템
+
+**CONDITIONAL - 연결이 약하다.**
+
+컨테스트에서 NPC는 "경쟁자 점수 생성"에만 사용된다. 하지만 NPC와의 관계가 컨테스트에 미치는 영향이 없다:
+
+- 꽃집 소연(florist)과 친밀도가 높으면 Flower Show에서 유리해야 자연스럽다
+- 셰프 이준과 친밀도가 높으면 Harvest Festival에서 심사 보너스가 있어야 한다
+
+> **Recommendation**: NPC 친밀도가 관련 컨테스트에서 소량의 점수 보너스를 제공:
+> ```
+> contest_affinity_bonus = 0
+> if (contest == FLOWER_SHOW && npc_florist.affinity >= 60): bonus += 0.03
+> if (contest == HARVEST_FESTIVAL && npc_chef.affinity >= 60): bonus += 0.03
+> ```
+
+### 5.3 랜덤 이벤트 <-> Phase 2 경제 시스템
+
+**CONDITIONAL - 연결점이 불명확하다.**
+
+Phase 2에서 정의된 시스템과의 인터페이스:
+
+| Phase 2 System | Phase 3 연결점 | 현재 상태 |
+|---------------|---------------|----------|
+| Shop (shop_items) | 이벤트 대응 아이템 구매 | 언급만 됨 ("살충제 50 coins") - shop_items에 추가 필요 |
+| Greenhouse (user_tools) | `shelter_protection` 폭풍 방어 | 정의됨 (Section 3.4) - OK |
+| User Resources (water tank) | Lucky Rain의 수분 회복 | 미정의 - Lucky Rain이 water tank에 영향을 주는지 불명확 |
+| Garden Grid (garden_plots) | `affected_plot_ids` 이벤트 영향 범위 | 정의됨 - OK |
+| Transaction (transactions) | 이벤트 대응 비용 로깅 | 미정의 - EconomyService 연동 필요 |
+
+> **Required Action**:
+> - Phase 2 `shop_items`에 추가할 이벤트 대응 아이템 목록 명시 (살충제, 살균제, 방풍막 등)
+> - Lucky Rain 이벤트가 `user_resources.water_current`를 회복시키는지 결정
+> - 이벤트 대응 비용을 `EconomyService.spendCoins()`로 처리하도록 명시
+
+### 5.4 계절 시스템 <-> 기존 SimulationService
+
+**CONDITIONAL - 통합 인터페이스가 불명확하다.**
+
+현재 `SimulationService.calculateGrowthRate()` 시그니처:
+
+```typescript
+calculateGrowthRate(
+  environment: { temperature?, humidity?, light_dli?, soil_moisture? },
+  plantEnvironment: any,
+  baseGrowthRate: number = 1.0
+): number
+```
+
+Phase 3 명세서의 보정 적용 공식 (Section 2.4):
+
+```
+effective_growth_rate = base_growth_rate
+                      * season_modifier.growth_rate
+                      * environment_match_factor
+                      * health_factor
+```
+
+여기서 `environment_match_factor`가 기존 `calculateGrowthRate()`의 반환값인지, 별도 계산인지 불명확하다. Phase 2 리뷰(ISSUE-11)에서 제안한 `plotBonuses`, `toolBonuses` 파라미터까지 합치면 시그니처가 복잡해진다.
+
+> **Required Action**: `calculateGrowthRate()` 최종 시그니처를 확정:
+> ```typescript
+> calculateGrowthRate(
+>   environment, plantEnvironment, baseRate = 1.0,
+>   seasonModifiers?: SeasonModifiers,
+>   plotBonuses?: PlotBonuses,
+>   toolBonuses?: ToolBonuses,
+>   eventModifiers?: EventModifiers  // 해충 debuff, Lucky Rain buff 등
+> ): number
+> ```
+> 또는 `GrowthContext` 객체 패턴으로 단순화:
+> ```typescript
+> interface GrowthContext {
+>   season: SeasonModifiers;
+>   plot: PlotBonuses;
+>   tool: ToolBonuses;
+>   event: EventModifiers;
+> }
+> calculateGrowthRate(environment, plantEnvironment, baseRate, context?: GrowthContext): number
+> ```
+
+### 5.5 데이터 모델 일관성 체크
+
+| Field | Phase 3 명세서 | Phase 2 명세서 | 일관성 |
+|-------|--------------|--------------|--------|
+| `user_plants.quality_score` | Section 8.2: `ALTER TABLE user_plants ADD COLUMN quality_score FLOAT DEFAULT 50.0` | Phase 2에 없음 | OK - 신규 |
+| `user_plants.care_score` | Section 8.2: `ADD COLUMN care_score FLOAT DEFAULT 50.0` | Phase 2에 없음 | OK - 신규 |
+| `user_plants.active_buffs` | Section 8.2: `ADD COLUMN active_buffs JSONB DEFAULT '[]'` | Phase 2에 없음 | **WARNING** - Phase 2 fertilizer도 buff인데, 별도로 `user_inventory.is_active`로 관리. 이중 관리 위험 |
+| `users.event_pity_counter` | Section 8.2: `ADD COLUMN event_pity_counter INTEGER DEFAULT 0` | Phase 2에 없음 | **WARNING** - pity는 `eventHistory`에서 계산하는데(Section 7.1), 별도 컬럼이 필요한 이유 불명확 |
+
+> **Required Action**:
+> - `active_buffs/active_debuffs` vs Phase 2의 `user_inventory.is_active` 관계 정리. 단일 소스(single source of truth) 결정
+> - `event_pity_counter`가 `eventHistory`에서 계산 가능하다면 제거하여 데이터 불일치 방지
+
+---
+
+## 6. Detailed Review: (5) 리스크 식별 - 82/100
+
+### 6.1 문서에 식별된 리스크 평가
+
+| Risk (문서 12.1) | 평가 |
+|-----------------|------|
+| 밸런스 붕괴 | GOOD - "시뮬레이션 1000회" 대응이 적절 |
+| 이벤트 스팸 | GOOD - 쿨다운 + 동시 제한 + 무시 기능 제안 |
+| NPC 퀘스트 불가능 조건 | PARTIAL - 식별했지만 해결 알고리즘이 명세에 없음 |
+| 컨테스트 NPC 점수 불공정 | GOOD - 레벨 스케일링 + 분산 조정 |
+| DB 성능 (JSONB 쿼리 부하) | PARTIAL - 인덱싱 전략 언급했지만 구체적 계획 없음 |
+
+### 6.2 누락된 리스크
+
+**RISK-A: 계절 강제 동기화로 인한 신규 유저 불이익**
+
+서버 전역 계절(Section 12.2.2)을 채택하면, 겨울에 가입한 신규 유저는:
+- 30일간 성장률 극히 저조 (대부분 0.1-0.6)
+- 높은 폭풍 확률로 피해 누적
+- NPC 퀘스트 수행 어려움 (재배할 수 있는 식물이 제한적)
+- 결론: 가입 시점에 따라 초반 경험이 극단적으로 달라짐
+
+> **Mitigation**: 신규 유저에게 첫 30일간 "초보자 보호 버프" 적용 (계절 보정 최소 0.5 보장, 이벤트 피해 50% 감소)
+
+**RISK-B: 10.5주 일정의 현실성**
+
+| Phase | Duration | Content Volume | Risk |
+|-------|----------|---------------|------|
+| 3-A: Season | 2주 | DB + Service + API + CSS + Particle | MEDIUM |
+| 3-B: Events | 2.5주 | DB + 5종 이벤트 핸들러 + 스케줄러 + UI | HIGH |
+| 3-C: NPC | 3주 | DB + 8 NPC + 퀘스트 엔진 + 친밀도 + UI 9개 태스크 | VERY HIGH |
+| 3-D: Contest | 2주 | DB + 4종 컨테스트 + 점수 알고리즘 + UI | HIGH |
+| 3-E: Integration | 1주 | 통합 테스트 + 밸런스 + 최적화 | MEDIUM |
+
+Phase 3-C (NPC 시스템)가 3주에 9개 태스크(DB + 방문 스케줄링 + 퀘스트 엔진 + 친밀도 + 보상 + API + UI 3종)를 소화해야 하므로 가장 위험하다.
+
+> **Mitigation**: Phase 3-C를 2개 서브 스프린트로 분할:
+> - 3-C.1 (2주): NPC 기본 시스템 (DB + 방문 + 기본 퀘스트 + API)
+> - 3-C.2 (1.5주): 친밀도 심화 + 보상 + 전체 UI
+> 총 일정을 11-12주로 조정
+
+**RISK-C: care_score 계산의 정의 부재**
+
+컨테스트 심사(Section 5.2)에서 `care_history_score` (가중치 15%)를 사용하지만, 이 점수가 어떻게 계산되는지 알고리즘이 없다. "물주기 적시성, 환경 유지 이력 기반 점수"라고만 되어 있다.
+
+기존 코드에는 care history를 추적하는 시스템이 없다. 이를 위해서는:
+- 물주기 시점 로깅
+- 환경 조건 일일 스냅샷
+- 적정 범위 유지 일수 계산
+
+이 모든 것이 새로운 인프라다.
+
+> **Required Action**: `care_score` 계산 알고리즘을 명시하거나, Phase 3 초기에는 quality_score와 health로 대체하고 care_score는 Phase 4에서 도입.
+
+---
+
+## 7. Checklist: Required Actions Before Implementation
+
+### Must Fix (구현 전 반드시 수정) - 8개
+
+| ID | Issue | Section | Priority |
+|----|-------|---------|----------|
+| ISSUE-1 | Disease 이벤트 상세 설계 추가 | 3.x (신규) | P0 |
+| ISSUE-2 | VISITOR 이벤트 카테고리 제거 또는 상세 정의 | 3.1 | P1 |
+| ISSUE-3 | Herb Contest & Rare Exhibit 심사 기준 추가 또는 연기 명시 | 5.x | P1 |
+| ISSUE-4 | 겨울 시즌 콘텐츠 보강 | 2.4, 2.5 | P0 |
+| ISSUE-6 | 오프라인 이벤트 처리 전략 확정 | 7.1, 12.2 | P0 |
+| ISSUE-7 | game_season 상태 관리 방식 확정 (stateless 권장) | 6.1, 8.1 | P0 |
+| - | EVENT_TYPES 순회 순서 shuffle 추가 | 7.1 | P1 |
+| - | active_buffs vs user_inventory.is_active 단일 소스 결정 | 8.2 | P1 |
+
+### Should Fix (구현 중 반영 권장) - 5개
+
+| ID | Issue | Section | Priority |
+|----|-------|---------|----------|
+| ISSUE-5 | 이벤트 대응에 전략적 선택지 추가 | 3.3 | P2 |
+| - | 퀘스트 생성 시 유저 보유 식물 상태 체크 | 4.4 | P2 |
+| - | NPC 친밀도-컨테스트 보너스 연동 | 5.2, 5.3 | P2 |
+| - | Phase 2 shop_items에 이벤트 대응 아이템 목록 명시 | 연동 | P2 |
+| - | care_score 계산 알고리즘 정의 또는 Phase 4 연기 | 5.2 | P2 |
+
+### Architecture Decisions Required
+
+| Decision | Options | Recommended |
+|----------|---------|-------------|
+| 오프라인 이벤트 처리 | (A) 일괄 처리 (B) 무시 (C) 감쇠 처리 | (C) 7일치까지 감쇠(0.5x) 처리 |
+| 계절 상태 관리 | (A) DB tick 저장 (B) Stateless 계산 | (B) Stateless |
+| VISITOR 이벤트 | (A) 제거 (B) 특별 방문자로 정의 | (A) 제거 |
+| 미구현 컨테스트 | (A) 4종 모두 구현 (B) 2종만 Phase 3 | (B) Flower Show + Harvest Festival만 |
+| GrowthRate 시그니처 | (A) 파라미터 추가 (B) Context 객체 | (B) GrowthContext 객체 |
+
+---
+
+## 8. Final Verdict
+
+### CONDITIONAL APPROVAL - 82/100
+
+설계 명세서의 전체적 방향과 아키텍처는 **승인**한다. 계절 사이클, 랜덤 이벤트, NPC 퀘스트, 친밀도, 컨테스트의 5대 시스템이 유기적으로 연결된 게임플레이 루프를 형성하며, 기존 Phase 1/2 코드와의 호환성이 잘 유지되어 있다. 알고리즘이 구현 가능한 수준으로 구체적이며, 확률/보상 수치가 합리적 범위에 있다.
+
+단, **Section 7의 "Must Fix" 8개 항목을 문서에 반영한 후** 구현에 착수해야 한다. 특히 다음 3가지가 핵심이다:
+
+1. **겨울 시즌 콘텐츠 보강** (ISSUE-4) - 현실 30일간 유저 이탈 방지의 핵심
+2. **오프라인 처리 전략 확정** (ISSUE-6) - 아키텍처의 근본적 결정
+3. **Disease 이벤트 상세 설계** (ISSUE-1) - 5개 이벤트 중 1개가 누락된 상태로는 구현 불가
+
+이 세 가지가 반영되면 Phase 3-A(Season Cycle System) 구현을 시작할 수 있다.
+
+### Score Breakdown
+
+```
+요구사항 완전성:        85/100  (Disease/Visitor/Contest 일부 누락으로 감점)
+게임플레이 다양성:       80/100  (겨울 콘텐츠 부족, 이벤트 대응 단순으로 감점)
+기술적 실행 가능성:      83/100  (오프라인 처리 미확정, game_season 동기화 이슈로 감점)
+시스템 간 일관성:        78/100  (Phase 2 연동 불명확, buff 이중 관리 위험으로 감점)
+리스크 식별:            82/100  (신규 유저 불이익, 일정 리스크 누락으로 감점)
+
+WEIGHTED AVERAGE:      82/100
+  = (85*0.25 + 80*0.20 + 83*0.25 + 78*0.15 + 82*0.15)
+  = 21.25 + 16.0 + 20.75 + 11.7 + 12.3
+  = 82.0
+```
+
+---
+
+*Review completed: 2026-04-24*

--- a/docs/MILESTONE_EVENT_NPC_SYSTEM.md
+++ b/docs/MILESTONE_EVENT_NPC_SYSTEM.md
@@ -1,0 +1,1613 @@
+# Plantii Phase 3 - Milestone: Event & NPC System
+
+> **Version**: 1.0
+> **Date**: 2026-04-24
+> **Status**: Planning
+> **Depends on**: Phase 1 (Core simulation), Phase 2 (Garden Management & Economy System)
+
+---
+
+## Table of Contents
+
+1. [Milestone Overview](#1-milestone-overview)
+2. [Season Cycle System](#2-season-cycle-system)
+3. [Random Event System](#3-random-event-system)
+4. [NPC Customer System](#4-npc-customer-system)
+5. [Season Contest System](#5-season-contest-system)
+6. [Core Data Structures](#6-core-data-structures)
+7. [Algorithm Specifications](#7-algorithm-specifications)
+8. [Database Migration Strategy](#8-database-migration-strategy)
+9. [API Endpoints](#9-api-endpoints)
+10. [Frontend Components](#10-frontend-components)
+11. [Implementation Roadmap](#11-implementation-roadmap)
+12. [Risk & Open Questions](#12-risk--open-questions)
+
+---
+
+## 1. Milestone Overview
+
+### 1.1 Goals
+
+이 마일스톤은 Plantii에 시간 흐름 기반 계절 시스템, 랜덤 이벤트, NPC 고객, 시즌 컨테스트를 추가하여 게임플레이 루프를 풍부하게 만든다.
+
+### 1.2 Dependency Graph
+
+```
+Phase 1: Core Simulation (plants, growth, auth)
+    |
+Phase 2: Garden Management & Economy (shop, tools, coins)
+    |
+Phase 3: Event & NPC System  <-- THIS MILESTONE
+    ├── Module A: Season Cycle System
+    ├── Module B: Random Event System  (depends on A)
+    ├── Module C: NPC Customer System  (depends on Phase 2 Economy)
+    └── Module D: Season Contest System (depends on A, C)
+```
+
+### 1.3 Key Constraints
+
+| Constraint | Detail |
+|------------|--------|
+| Backend Stack | Node.js + Express + TypeScript + PostgreSQL/Knex (기존 유지) |
+| Frontend Stack | React 18 + TypeScript + Vite + Tailwind (기존 유지) |
+| Game Time | 현실 1일 = 게임 내 1일. 계절은 현실 시간 기반으로 진행 |
+| Backward Compatibility | 기존 user_plants, plants 테이블 구조 유지. 신규 테이블/컬럼 추가만 허용 |
+
+---
+
+## 2. Season Cycle System
+
+### 2.1 Season Definitions
+
+```typescript
+enum Season {
+  SPRING = 'spring',  // 봄
+  SUMMER = 'summer',  // 여름
+  AUTUMN = 'autumn',  // 가을
+  WINTER = 'winter',  // 겨울
+}
+```
+
+| Season | Game Duration | Real Duration | Temp Range (C) | Humidity Range (%) | Light (hours) |
+|--------|--------------|---------------|-----------------|-------------------|---------------|
+| SPRING | 30 game-days | 30 real-days | 12-22 | 55-70 | 12-14 |
+| SUMMER | 30 game-days | 30 real-days | 25-35 | 60-80 | 14-16 |
+| AUTUMN | 30 game-days | 30 real-days | 8-20 | 45-65 | 10-12 |
+| WINTER | 30 game-days | 30 real-days | -5-10 | 30-50 | 8-10 |
+
+**Full Cycle**: 120일 (약 4개월) = 1 게임 년도
+
+### 2.2 Season Transition Mechanism
+
+```typescript
+interface SeasonTransition {
+  current_season: Season;
+  next_season: Season;
+  transition_start_day: number;   // 전환 시작 (계절 마지막 3일)
+  transition_duration: number;    // 3 game-days
+  blend_factor: number;           // 0.0 (current) -> 1.0 (next)
+}
+```
+
+**전환 알고리즘**:
+
+```
+// 계절 결정
+function getCurrentSeason(gameDayInYear: number): Season {
+  // gameDayInYear: 1-120
+  if (gameDayInYear <= 30) return SPRING;
+  if (gameDayInYear <= 60) return SUMMER;
+  if (gameDayInYear <= 90) return AUTUMN;
+  return WINTER;
+}
+
+// 전환 블렌드 팩터 (마지막 3일)
+function getTransitionBlend(gameDayInSeason: number): number {
+  if (gameDayInSeason <= 27) return 0.0;  // 순수 현재 계절
+  return (gameDayInSeason - 27) / 3.0;    // 28일: 0.33, 29일: 0.67, 30일: 1.0
+}
+
+// 블렌드된 환경 값
+function blendedValue(currentVal, nextVal, blend): number {
+  return currentVal * (1 - blend) + nextVal * blend;
+}
+```
+
+### 2.3 Season Visual Changes
+
+| Season | Background Palette | Particle Effects | UI Theme |
+|--------|-------------------|------------------|----------|
+| SPRING | Soft green (#A8D5BA), Light pink (#F4C2C2) | Cherry blossom petals, Light rain | Pastel borders, Flower icons |
+| SUMMER | Bright green (#4CAF50), Sky blue (#87CEEB) | Sunlight rays, Heat shimmer | Bold colors, Sun icons |
+| AUTUMN | Orange (#FF9800), Brown (#795548) | Falling leaves, Fog | Warm tones, Leaf icons |
+| WINTER | White (#F5F5F5), Ice blue (#B3E5FC) | Snowflakes, Frost overlay | Cool tones, Snowflake icons |
+
+**CSS Variable Approach**:
+
+```css
+:root[data-season="spring"] {
+  --bg-primary: #A8D5BA;
+  --bg-secondary: #F4C2C2;
+  --accent: #E91E63;
+  --particle-type: 'cherry-blossom';
+}
+/* ... same pattern for summer, autumn, winter */
+```
+
+### 2.4 Season Growth Modifiers
+
+각 식물 카테고리별 계절 보정 계수:
+
+```typescript
+interface SeasonModifiers {
+  growth_rate: number;   // 성장 속도 배율 (기본 1.0)
+  yield_bonus: number;   // 수확량 보정 (기본 1.0)
+  quality_bonus: number; // 품질 보정 (기본 1.0)
+}
+```
+
+**카테고리별 계절 보정 매트릭스**:
+
+| Category | Spring | Summer | Autumn | Winter |
+|----------|--------|--------|--------|--------|
+| **flowering** (화훼류) | growth: 1.3, yield: 1.2, quality: 1.3 | growth: 1.1, yield: 1.0, quality: 0.9 | growth: 0.7, yield: 0.8, quality: 1.1 | growth: 0.3, yield: 0.4, quality: 0.6 |
+| **succulent** (다육류) | growth: 1.0, yield: 1.0, quality: 1.0 | growth: 1.2, yield: 1.1, quality: 1.0 | growth: 0.9, yield: 0.9, quality: 1.0 | growth: 0.6, yield: 0.7, quality: 0.8 |
+| **herb** (허브) | growth: 1.4, yield: 1.3, quality: 1.2 | growth: 1.2, yield: 1.1, quality: 1.0 | growth: 0.8, yield: 0.9, quality: 1.1 | growth: 0.2, yield: 0.3, quality: 0.5 |
+| **leafy** (엽채류) | growth: 1.3, yield: 1.2, quality: 1.2 | growth: 0.8, yield: 0.7, quality: 0.7 | growth: 1.1, yield: 1.1, quality: 1.3 | growth: 0.4, yield: 0.5, quality: 0.6 |
+| **fruit** (과채류) | growth: 1.1, yield: 1.0, quality: 1.0 | growth: 1.4, yield: 1.5, quality: 1.2 | growth: 0.9, yield: 1.2, quality: 1.4 | growth: 0.1, yield: 0.2, quality: 0.4 |
+| **foliage** (관엽류) | growth: 1.1, yield: 1.0, quality: 1.0 | growth: 1.2, yield: 1.0, quality: 1.0 | growth: 0.9, yield: 0.9, quality: 1.0 | growth: 0.5, yield: 0.5, quality: 0.7 |
+
+**보정 적용 공식**:
+
+```
+effective_growth_rate = base_growth_rate
+                      * season_modifier.growth_rate
+                      * environment_match_factor
+                      * health_factor
+
+effective_yield = base_yield
+                * season_modifier.yield_bonus
+                * quality_grade_multiplier
+
+effective_quality = base_quality_score
+                  * season_modifier.quality_bonus
+                  * care_consistency_bonus   // 지속적 관리 보너스 (0.9-1.2)
+```
+
+### 2.5 Season-Specific Plant Behaviors
+
+```typescript
+interface SeasonPlantBehavior {
+  // 겨울 휴면
+  dormancy: {
+    affected_categories: ['flowering', 'herb', 'fruit'];
+    growth_halt_threshold: 0.3;  // growth_rate < 0.3 이면 휴면 진입
+    health_drain_rate: 0.0;      // 휴면 중 건강도 감소 없음
+    water_need_reduction: 0.5;   // 물 필요량 50% 감소
+  };
+
+  // 봄 개화 부스트
+  spring_bloom: {
+    affected_categories: ['flowering'];
+    bloom_chance_bonus: 0.3;     // 개화 확률 +30%
+    special_reward_chance: 0.1;  // 특별 보상 확률 10%
+  };
+
+  // 여름 폭풍 취약
+  summer_vulnerability: {
+    storm_damage_multiplier: 1.5;  // 폭풍 피해 1.5배
+    heat_stress_threshold: 32;     // 32도 이상 열 스트레스
+  };
+}
+```
+
+---
+
+## 3. Random Event System
+
+### 3.1 Event Categories
+
+```typescript
+enum EventCategory {
+  PEST = 'pest',           // 해충 피해
+  STORM = 'storm',         // 폭풍
+  LUCKY_RAIN = 'lucky_rain', // 행운의 비
+  RARE_SEED = 'rare_seed',   // 희귀 씨앗
+  DISEASE = 'disease',       // 질병
+  VISITOR = 'visitor',       // 특별 방문자 (NPC 시스템과 연동)
+}
+
+enum EventSeverity {
+  MINOR = 'minor',
+  MODERATE = 'moderate',
+  MAJOR = 'major',
+  CRITICAL = 'critical',
+}
+```
+
+### 3.2 Event Probability Matrix
+
+**기본 발생 확률 (1 game-day 당)**:
+
+| Event | Spring | Summer | Autumn | Winter | Base Prob/Day |
+|-------|--------|--------|--------|--------|---------------|
+| **Pest (해충)** | 0.08 | 0.15 | 0.06 | 0.02 | 0.08 |
+| **Storm (폭풍)** | 0.05 | 0.12 | 0.08 | 0.10 | 0.09 |
+| **Lucky Rain (행운의 비)** | 0.10 | 0.05 | 0.08 | 0.03 | 0.07 |
+| **Rare Seed (희귀 씨앗)** | 0.03 | 0.02 | 0.04 | 0.01 | 0.025 |
+| **Disease (질병)** | 0.04 | 0.08 | 0.05 | 0.03 | 0.05 |
+
+**가중치 보정 요인**:
+
+```
+final_probability = base_probability
+                  * season_weight
+                  * garden_size_factor         // 밭 칸 수에 비례 (1 + plot_count * 0.02)
+                  * consecutive_day_factor     // 이벤트 없는 연속일 보너스 (pity system)
+                  * level_scaling              // 유저 레벨 스케일링 (1 + level * 0.01)
+```
+
+**Pity System (연속 미발생 보정)**:
+
+```
+consecutive_day_factor = 1.0 + (days_since_last_event * 0.05)
+// 최대 2.0 (20일 연속 이벤트 없을 시)
+```
+
+### 3.3 Pest Event (해충 피해)
+
+```typescript
+interface PestEvent {
+  type: 'pest';
+  severity: EventSeverity;
+  pest_species: string;
+  affected_plots: PlotId[];     // 영향 받는 밭 칸들
+  damage_rate: number;          // 피해율 (0.0 - 1.0)
+  spread_chance: number;        // 인접 칸 전파 확률
+  duration_days: number;        // 지속 일수
+  countermeasure: string;       // 대응 수단
+}
+```
+
+| Severity | Damage Rate | Spread Range | Duration | Countermeasure Cost |
+|----------|------------|--------------|----------|-------------------|
+| MINOR | 0.05-0.10 | 0 (해당 칸만) | 1일 | 50 coins (살충제) |
+| MODERATE | 0.15-0.25 | 인접 1칸 (25%) | 2일 | 150 coins |
+| MAJOR | 0.30-0.45 | 인접 2칸 (50%) | 3일 | 400 coins |
+| CRITICAL | 0.50-0.70 | 전체 밭 (30%) | 5일 | 800 coins + 특수 아이템 |
+
+**해충 종류**:
+
+| Pest | Affected Categories | Season Peak | Damage Type |
+|------|-------------------|-------------|-------------|
+| 진딧물 (Aphid) | flowering, herb, leafy | Spring | 성장 속도 감소 |
+| 응애 (Mite) | succulent, foliage | Summer | 건강도 감소 |
+| 배추흰나비 유충 (Cabbage Worm) | leafy, herb | Spring/Autumn | 수확량 감소 |
+| 곰팡이 (Fungus Gnat) | ALL | Summer (high humidity) | 뿌리 손상 → 건강도 급감 |
+| 달팽이 (Snail) | leafy, herb | Spring (rainy) | 잎 손상 → 품질 감소 |
+
+**피해 계산**:
+
+```
+daily_damage = damage_rate * (1 - plant_resistance) * severity_multiplier
+
+plant_health -= daily_damage * 100
+plant_growth_progress -= daily_damage * growth_penalty_factor
+
+// 식물별 저항력
+plant_resistance = {
+  succulent: 0.3,  // 다육류 해충 저항 높음
+  herb: 0.2,       // 일부 허브 저항
+  default: 0.0,
+}
+```
+
+### 3.4 Storm Event (폭풍)
+
+```typescript
+interface StormEvent {
+  type: 'storm';
+  severity: EventSeverity;
+  storm_type: 'rain' | 'wind' | 'hail' | 'thunderstorm';
+  affected_area: 'all';       // 전체 밭 영향
+  damage_rate: number;
+  soil_moisture_change: number;
+  duration_hours: number;      // 게임 내 시간
+}
+```
+
+| Storm Type | Severity Distribution | Crop Damage | Moisture Change | Frequency/Season |
+|------------|----------------------|-------------|-----------------|-----------------|
+| rain (비) | MINOR: 70%, MOD: 25%, MAJ: 5% | 0.0-0.05 | +20-40% | Summer: 3-4/season |
+| wind (강풍) | MINOR: 40%, MOD: 40%, MAJ: 15%, CRIT: 5% | 0.05-0.30 | -5-15% | Autumn: 2-3/season |
+| hail (우박) | MOD: 50%, MAJ: 35%, CRIT: 15% | 0.15-0.50 | +10-20% | Spring/Summer: 0-1/season |
+| thunderstorm (뇌우) | MOD: 30%, MAJ: 50%, CRIT: 20% | 0.10-0.40 | +30-50% | Summer: 1-2/season |
+
+**폭풍 피해 계산**:
+
+```
+storm_damage_per_plant = base_damage
+                       * storm_severity_multiplier
+                       * plant_fragility_factor        // 식물별 취약도
+                       * (1 - shelter_protection)      // 보호 시설 감소
+
+// 식물 취약도
+plant_fragility = {
+  flowering: 0.8,   // 꽃은 폭풍에 약함
+  herb: 0.6,
+  leafy: 0.7,
+  fruit: 0.5,
+  succulent: 0.3,   // 다육류 강인
+  foliage: 0.4,
+}
+
+// 보호 시설 (Shop에서 구매 가능 - Phase 2 연동)
+shelter_protection = {
+  none: 0.0,
+  basic_fence: 0.2,
+  greenhouse: 0.6,
+  reinforced_greenhouse: 0.85,
+}
+```
+
+### 3.5 Lucky Rain Event (행운의 비)
+
+```typescript
+interface LuckyRainEvent {
+  type: 'lucky_rain';
+  bonus_type: 'growth' | 'quality' | 'both';
+  growth_boost: number;        // 성장 촉진 배율 (1.5-3.0)
+  quality_boost: number;       // 품질 상승 배율 (1.2-2.0)
+  duration_days: number;       // 지속 일수 (1-3)
+  affected_area: 'all';
+  rainbow_bonus: boolean;      // 무지개 출현 시 추가 보너스
+}
+```
+
+| Tier | Probability | Growth Boost | Quality Boost | Duration | Rainbow Chance |
+|------|------------|--------------|---------------|----------|---------------|
+| Light Drizzle (이슬비) | 60% | x1.5 | x1.2 | 1일 | 5% |
+| Golden Rain (금빛 비) | 30% | x2.0 | x1.5 | 2일 | 20% |
+| Miracle Rain (기적의 비) | 10% | x3.0 | x2.0 | 3일 | 50% |
+
+**무지개 보너스**: 발현 시 모든 식물 건강도 +10, 경험치 x1.5 (해당 기간)
+
+### 3.6 Rare Seed Event (희귀 씨앗)
+
+```typescript
+interface RareSeedEvent {
+  type: 'rare_seed';
+  seed_id: string;
+  seed_rarity: 'uncommon' | 'rare' | 'epic' | 'legendary';
+  discovery_method: 'ground' | 'bird_drop' | 'wind_blown' | 'mystery_package';
+  claim_deadline_hours: number;  // 수령 제한 시간
+}
+```
+
+**희귀 씨앗 드롭 테이블**:
+
+| Seed | Rarity | Drop Rate | Growth Time | Sell Value | Special Trait |
+|------|--------|-----------|-------------|------------|---------------|
+| 황금 장미 (Golden Rose) | Epic | 0.8% | 120일 | 5,000 coins | 판매가 5x, 빛나는 이펙트 |
+| 무지개 튤립 (Rainbow Tulip) | Rare | 2.0% | 60일 | 2,000 coins | 모든 계절 성장 가능 |
+| 거대 해바라기 (Giant Sunflower) | Uncommon | 5.0% | 75일 | 1,500 coins | 수확량 3x |
+| 크리스탈 선인장 (Crystal Cactus) | Legendary | 0.3% | 180일 | 15,000 coins | 주변 식물 성장 +20% 오라 |
+| 달빛 라벤더 (Moonlight Lavender) | Rare | 1.5% | 50일 | 2,500 coins | 야간 성장 2x |
+| 별빛 민트 (Starlight Mint) | Uncommon | 4.0% | 35일 | 800 coins | 해충 저항 100% |
+| 용의 고추 (Dragon Pepper) | Epic | 0.5% | 100일 | 8,000 coins | 인접 식물 열 보호 |
+| 요정 바질 (Fairy Basil) | Rare | 1.8% | 40일 | 1,800 coins | 품질 항상 S등급 |
+
+**드롭율 보정**:
+
+```
+actual_drop_rate = base_drop_rate
+                 * (1 + user_level * 0.02)          // 레벨 보정
+                 * season_rare_modifier              // 가을: x1.5, 봄: x1.2
+                 * (1 + garden_diversity_bonus)       // 5종 이상 재배 시 +0.1
+```
+
+### 3.7 Event Scheduling Algorithm
+
+```typescript
+interface EventScheduler {
+  // 1일 1회 cron job에서 실행 (simulationCron.ts 확장)
+  processDaily(userId: string): Promise<GameEvent[]>;
+
+  // 이벤트 큐 관리
+  event_queue: PriorityQueue<GameEvent>;
+
+  // 동시 이벤트 제한
+  max_concurrent_events: 3;
+
+  // 최소 이벤트 간격
+  min_event_gap_days: 1;
+
+  // 이벤트 쿨다운 (같은 타입)
+  cooldown_by_type: {
+    pest: 3,        // 3일
+    storm: 2,       // 2일
+    lucky_rain: 5,  // 5일
+    rare_seed: 7,   // 7일
+    disease: 4,     // 4일
+  };
+}
+```
+
+**Daily Event Processing**:
+
+```
+function processDaily(userId):
+  1. 현재 계절 및 게임 일차 조회
+  2. 활성 이벤트 목록 조회 → 만료된 이벤트 정리
+  3. 동시 이벤트 수 체크 (< max_concurrent_events)
+  4. 각 이벤트 타입에 대해:
+     a. 쿨다운 체크 → 쿨다운 중이면 SKIP
+     b. final_probability 계산 (base * season * pity * level)
+     c. Math.random() < final_probability → 이벤트 생성
+     d. severity 결정 (가중 랜덤)
+     e. 영향 범위 계산
+     f. event_queue에 추가
+  5. 이벤트 효과 적용 (피해, 버프 등)
+  6. 이벤트 알림 생성
+  7. 유저에게 Push Notification (선택)
+```
+
+---
+
+## 4. NPC Customer System
+
+### 4.1 NPC Definitions
+
+```typescript
+interface NPC {
+  id: string;
+  name_ko: string;
+  name_en: string;
+  personality: NPCPersonality;
+  preferred_plants: string[];       // 선호 식물 ID 목록
+  preferred_quality: QualityGrade;  // 선호 품질 등급
+  visit_frequency: VisitFrequency;
+  affinity: number;                 // 친밀도 (0-100)
+  sprite_id: string;
+  dialogue_pool: DialogueSet;
+}
+
+enum NPCPersonality {
+  FRIENDLY = 'friendly',
+  PICKY = 'picky',
+  GENEROUS = 'generous',
+  MYSTERIOUS = 'mysterious',
+  COLLECTOR = 'collector',
+}
+
+enum QualityGrade {
+  D = 'd',  // 60 미만
+  C = 'c',  // 60-69
+  B = 'b',  // 70-79
+  A = 'a',  // 80-89
+  S = 's',  // 90-100
+}
+```
+
+### 4.2 NPC Roster
+
+| ID | Name | Personality | Preferred Plants | Quality Req | Visit Freq | Unlock Condition |
+|----|------|------------|-----------------|-------------|-----------|-----------------|
+| npc_grandma | 김할머니 | FRIENDLY | leafy, herb | C+ | High (daily possible) | 즉시 |
+| npc_chef | 셰프 이준 | PICKY | herb, fruit (tomato, chili) | A+ | Medium (2-3d) | Level 5 |
+| npc_florist | 꽃집 소연 | COLLECTOR | flowering (rose, tulip, sunflower) | B+ | Medium (2-3d) | Level 3 |
+| npc_scientist | 박사님 | MYSTERIOUS | ALL (rare preferred) | ANY | Low (5-7d) | Level 10 |
+| npc_child | 꼬마 민수 | FRIENDLY | succulent, flowering | ANY | High (1-2d) | 즉시 |
+| npc_merchant | 상인 하영 | GENEROUS | fruit, leafy | B+ | Low (4-5d) | Level 7 |
+| npc_herbalist | 약초꾼 | COLLECTOR | herb (lavender, basil, mint) | A+ | Medium (3-4d) | Level 8 |
+| npc_elderly | 원예왕 할아버지 | PICKY | foliage (monstera, rubber) | S only | Very Low (7-10d) | Level 15 |
+
+### 4.3 NPC Visit Conditions & Frequency
+
+```typescript
+interface VisitCondition {
+  // 방문 가능 조건
+  min_user_level: number;
+  required_plant_count: number;    // 최소 보유 식물 수
+  required_harvestable: number;    // 수확 가능 식물 수
+  season_preference: Season[];     // 선호 계절 (빈 배열 = 무관)
+  time_window: {                   // 방문 가능 시간대 (게임 내)
+    start_hour: number;
+    end_hour: number;
+  };
+}
+```
+
+**Visit Probability Algorithm**:
+
+```
+function calculateVisitProbability(npc, user, season):
+  base_rate = npc.base_visit_rate   // 0.1 ~ 1.0
+
+  // 조건 충족 여부
+  if user.level < npc.min_user_level: return 0
+  if user.harvestable_count < npc.required_harvestable: return 0
+
+  // 계절 보정
+  season_mod = npc.season_preference.includes(season) ? 1.3 : 1.0
+
+  // 친밀도 보정 (친밀도 높을수록 자주 방문)
+  affinity_mod = 1.0 + (npc.affinity / 100) * 0.5
+
+  // 선호 식물 보유 보정
+  has_preferred = user.plants.some(p => npc.preferred_plants.includes(p.category))
+  preference_mod = has_preferred ? 1.4 : 0.8
+
+  return min(base_rate * season_mod * affinity_mod * preference_mod, 0.95)
+```
+
+### 4.4 Quest Generation Logic
+
+```typescript
+interface Quest {
+  id: string;
+  npc_id: string;
+  type: QuestType;
+  requirements: QuestRequirement[];
+  rewards: QuestReward;
+  deadline_days: number;           // 완료 기한 (game-days)
+  difficulty: 'easy' | 'medium' | 'hard' | 'legendary';
+  dialogue_intro: string;
+  dialogue_complete: string;
+  dialogue_fail: string;
+}
+
+enum QuestType {
+  DELIVER = 'deliver',           // 작물 납품
+  GROW = 'grow',                 // 특정 작물 재배
+  QUALITY = 'quality',           // 특정 품질 이상 달성
+  COLLECTION = 'collection',     // 여러 종류 수집
+  SPECIAL = 'special',           // 특수 퀘스트
+}
+
+interface QuestRequirement {
+  plant_id?: string;             // 특정 식물 (null = any in category)
+  plant_category?: string;       // 카테고리 지정
+  quantity: number;              // 요구 수량
+  min_quality: QualityGrade;     // 최소 품질
+  is_rare?: boolean;             // 희귀 품종 요구 여부
+}
+```
+
+**Quest Generation Algorithm**:
+
+```
+function generateQuest(npc, user):
+  // 1. 난이도 결정 (유저 레벨 기반)
+  difficulty = selectDifficulty(user.level, npc.personality)
+
+  // 2. 퀘스트 타입 결정
+  type_weights = {
+    DELIVER: npc.personality == 'FRIENDLY' ? 0.5 : 0.3,
+    GROW: 0.2,
+    QUALITY: npc.personality == 'PICKY' ? 0.4 : 0.15,
+    COLLECTION: npc.personality == 'COLLECTOR' ? 0.5 : 0.1,
+    SPECIAL: npc.affinity >= 80 ? 0.15 : 0.0,
+  }
+  type = weightedRandom(type_weights)
+
+  // 3. 요구사항 생성
+  plants = selectFromPreferred(npc.preferred_plants, difficulty)
+  quantity = difficultyToQuantity(difficulty)   // easy:1-2, med:2-4, hard:3-6, legend:5-10
+  quality = npc.preferred_quality               // NPC 성격 반영
+
+  // 4. 기한 설정
+  deadline = difficultyToDeadline(difficulty)   // easy:7d, med:5d, hard:3d, legend:10d
+
+  // 5. 보상 계산
+  rewards = calculateRewards(difficulty, npc, quantity)
+
+  return Quest { type, requirements, rewards, deadline, difficulty }
+```
+
+**난이도별 퀘스트 파라미터**:
+
+| Difficulty | Quantity | Min Quality | Deadline | Base Coin Reward | XP Reward |
+|-----------|----------|------------|----------|-----------------|-----------|
+| easy | 1-2 | D | 7일 | 100-300 | 50-100 |
+| medium | 2-4 | C | 5일 | 300-800 | 100-250 |
+| hard | 3-6 | A | 3일 | 800-2,000 | 250-500 |
+| legendary | 5-10 | S | 10일 | 3,000-10,000 | 500-1,500 |
+
+### 4.5 Affinity System (친밀도)
+
+```typescript
+interface AffinitySystem {
+  max_affinity: 100;
+  decay_rate: 0;                   // 친밀도는 감소하지 않음 (유저 친화적)
+
+  // 친밀도 획득 방법
+  gain_events: {
+    quest_complete: 5-15;          // 퀘스트 완료 (난이도별)
+    quest_bonus: 5;                // 기한 내 2일 이상 여유로 완료
+    preferred_plant_gift: 3;       // 선호 식물 선물
+    daily_greeting: 1;             // 일일 인사 (1일 1회)
+    perfect_quality: 3;            // S등급 납품
+  };
+
+  // 친밀도 감소 방법
+  loss_events: {
+    quest_fail: -5;                // 퀘스트 실패
+    quest_expire: -3;              // 퀘스트 만료
+  };
+}
+```
+
+**Affinity Milestones & Rewards**:
+
+| Level | Affinity | Title | Reward |
+|-------|---------|-------|--------|
+| 1 | 0-19 | 낯선 사이 | 기본 퀘스트만 가능 |
+| 2 | 20-39 | 아는 사이 | 퀘스트 보상 +10%, 중급 퀘스트 해금 |
+| 3 | 40-59 | 친한 사이 | 퀘스트 보상 +20%, 상급 퀘스트 해금, NPC 특별 아이템 할인 10% |
+| 4 | 60-79 | 절친한 사이 | 퀘스트 보상 +30%, NPC 전용 아이템 구매 가능, 할인 20% |
+| 5 | 80-99 | 소울메이트 | 퀘스트 보상 +50%, 전설 퀘스트 해금, 특별 대화/스토리 |
+| MAX | 100 | 영혼의 벗 | 일회성 특별 보상 아이템, NPC 칭호, 유니크 이펙트 |
+
+**NPC별 Max Affinity 특별 보상**:
+
+| NPC | Max Affinity Reward |
+|-----|-------------------|
+| 김할머니 | "할머니의 비법 물약" - 모든 작물 건강도 즉시 100% 회복 (소모품 x3) |
+| 셰프 이준 | "미슐랭 조리법" - 과일/허브 판매가 영구 +15% |
+| 꽃집 소연 | "황금 화분" - 꽃 카테고리 성장 속도 영구 +10% |
+| 박사님 | "돌연변이 촉진제" - 희귀 씨앗 드롭율 영구 +50% |
+| 꼬마 민수 | "행운의 클로버" - 행운의 비 확률 영구 +20% |
+| 상인 하영 | "VIP 거래증" - 모든 판매가 영구 +10% |
+| 약초꾼 | "고대 허브 도감" - 허브 품질 영구 +1등급 |
+| 원예왕 할아버지 | "마스터의 인장" - 모든 식물 성장 속도 영구 +5%, 특별 칭호 |
+
+### 4.6 Quest Complete Rewards
+
+```typescript
+interface QuestReward {
+  coins: number;
+  experience: number;
+  affinity_gain: number;
+  bonus_items?: BonusItem[];       // 확률적 추가 보상
+}
+
+interface BonusItem {
+  item_id: string;
+  quantity: number;
+  drop_chance: number;             // 0.0-1.0
+}
+```
+
+**보상 계산 공식**:
+
+```
+final_coin_reward = base_coins
+                  * difficulty_multiplier       // easy:1.0, med:1.5, hard:2.5, legend:5.0
+                  * affinity_bonus              // 1.0 + affinity_level * 0.1
+                  * quality_bonus               // 요구보다 높은 품질 납품 시 +20% per grade
+                  * speed_bonus                 // 기한의 50% 이내 완료 시 +25%
+
+final_xp_reward = base_xp
+                * difficulty_multiplier
+                * first_time_bonus              // 해당 NPC 첫 퀘스트 완료 시 x2.0
+```
+
+---
+
+## 5. Season Contest System
+
+### 5.1 Contest Types
+
+```typescript
+interface Contest {
+  id: string;
+  type: ContestType;
+  season: Season;
+  name_ko: string;
+  entry_requirements: EntryRequirement;
+  judging_criteria: JudgingCriteria[];
+  prizes: ContestPrize[];
+  schedule: ContestSchedule;
+  max_participants: number;        // 순위 경쟁 대상 (NPC 포함)
+}
+
+enum ContestType {
+  FLOWER_SHOW = 'flower_show',         // 꽃 품평회
+  HARVEST_FESTIVAL = 'harvest_festival', // 수확 축제
+  HERB_CONTEST = 'herb_contest',       // 허브 경연
+  RARE_EXHIBIT = 'rare_exhibit',       // 희귀 식물 전시
+}
+```
+
+### 5.2 Flower Show (꽃 품평회)
+
+**Schedule**: 봄 시즌 20-25일 (연 1회)
+
+```typescript
+interface FlowerShowEntry {
+  plant_id: string;                // flowering 카테고리만 가능
+  quality_score: number;           // 0-100
+  health: number;                  // 0-100
+  growth_completion: number;       // 0.0-1.0 (개화 상태)
+  care_history_score: number;      // 관리 이력 점수
+}
+```
+
+**심사 기준**:
+
+| Criteria | Weight | Scoring Method |
+|----------|--------|---------------|
+| 품질 (Quality) | 35% | quality_score 직접 반영 |
+| 건강도 (Health) | 20% | health / 100 |
+| 개화 상태 (Bloom) | 25% | growth_stage == 'flowering' ? 1.0 : 0.5 |
+| 관리 이력 (Care) | 15% | 물주기 적시성, 환경 유지 이력 기반 점수 |
+| 희귀도 (Rarity) | 5% | common: 0.5, uncommon: 0.7, rare: 0.85, epic: 0.95, legendary: 1.0 |
+
+**순위 계산**:
+
+```
+total_score = quality * 0.35
+            + (health / 100) * 0.20
+            + bloom_score * 0.25
+            + care_score * 0.15
+            + rarity_score * 0.05
+
+// NPC 경쟁자 점수 (레벨 스케일링)
+npc_competitor_scores = generateNPCScores(user.level, contest_difficulty)
+// NPC는 3-5명, 점수 범위: user_level_based ± random_variance
+```
+
+**NPC 경쟁자 점수 생성**:
+
+```
+function generateNPCScores(userLevel, count = 4):
+  base = 40 + userLevel * 2.5        // 레벨에 비례
+  scores = []
+  for i in range(count):
+    variance = random(-15, +15)
+    scores.push(clamp(base + variance, 20, 98))
+  return scores.sort(DESC)
+```
+
+**상품**:
+
+| Rank | Prize |
+|------|-------|
+| 1st (금상) | 3,000 coins + "꽃의 여왕/왕" 칭호 + 황금 화분 (성장 +15%) + 500 XP |
+| 2nd (은상) | 1,500 coins + 은빛 화분 (성장 +10%) + 300 XP |
+| 3rd (동상) | 800 coins + 동 화분 (성장 +5%) + 200 XP |
+| 참가상 | 200 coins + 50 XP + 특별 비료 x3 |
+
+### 5.3 Harvest Festival (수확 축제)
+
+**Schedule**: 가을 시즌 20-25일 (연 1회)
+
+```typescript
+interface HarvestFestivalEntry {
+  entries: HarvestEntry[];          // 최대 5개 작물 출품
+  total_harvest_value: number;      // 총 수확 가치
+  variety_count: number;            // 출품 종류 수
+}
+
+interface HarvestEntry {
+  plant_id: string;
+  category: string;                 // leafy, fruit, herb 카테고리만
+  quantity: number;
+  quality_grade: QualityGrade;
+  total_value: number;
+}
+```
+
+**우승 조건 (복합 점수)**:
+
+| Criteria | Weight | Description |
+|----------|--------|-------------|
+| 총 수확가치 (Total Value) | 40% | 출품 작물 총 판매가치 |
+| 품질 평균 (Avg Quality) | 25% | 전체 출품 작물 평균 품질 등급 |
+| 다양성 (Variety) | 20% | 서로 다른 카테고리 수 (max 3점) |
+| 수량 (Quantity) | 15% | 총 출품 수량 |
+
+```
+harvest_score = (total_value / max_possible_value) * 0.40
+              + (avg_quality_normalized) * 0.25
+              + (variety_count / 3) * 0.20
+              + (total_quantity / max_quantity) * 0.15
+```
+
+**상품**:
+
+| Rank | Prize |
+|------|-------|
+| 1st (풍요의 왕) | 5,000 coins + "풍요의 왕" 칭호 + 수확량 영구 +10% 패시브 + 800 XP |
+| 2nd | 2,500 coins + 수확량 +5% (해당 시즌) + 500 XP |
+| 3rd | 1,200 coins + 300 XP |
+| 참가상 | 300 coins + 100 XP + 고급 비료 x5 |
+
+### 5.4 Contest Schedule & Participation
+
+```typescript
+interface ContestSchedule {
+  announcement_day: number;         // 계절 시작 후 알림 일
+  registration_start: number;       // 등록 시작일
+  registration_end: number;         // 등록 마감일
+  contest_day: number;              // 대회 당일
+  result_announcement_day: number;  // 결과 발표일
+}
+```
+
+**연간 컨테스트 캘린더**:
+
+| Contest | Season | Announce | Register | Contest | Results |
+|---------|--------|----------|----------|---------|---------|
+| Flower Show | Spring | Day 5 | Day 10-18 | Day 20-22 | Day 23 |
+| Herb Contest | Summer | Day 5 | Day 10-18 | Day 20-22 | Day 23 |
+| Harvest Festival | Autumn | Day 5 | Day 10-18 | Day 20-22 | Day 23 |
+| Rare Exhibit | Winter | Day 10 | Day 15-22 | Day 25-27 | Day 28 |
+
+**참가 조건**:
+
+| Contest | Min Level | Required Plants | Entry Fee | Max Entries |
+|---------|----------|----------------|-----------|-------------|
+| Flower Show | 3 | 1+ flowering at bloom stage | 100 coins | 1 식물 |
+| Herb Contest | 5 | 1+ herb at harvest stage | 150 coins | 1 식물 |
+| Harvest Festival | 5 | 3+ harvestable plants | 200 coins | 최대 5 작물 |
+| Rare Exhibit | 10 | 1+ rare/epic/legendary plant | 500 coins | 1 식물 |
+
+---
+
+## 6. Core Data Structures
+
+### 6.1 Season State
+
+```typescript
+// 서버 전역 상태 (모든 유저 공유)
+interface GlobalSeasonState {
+  current_season: Season;
+  current_day_in_season: number;    // 1-30
+  current_year: number;             // 게임 년도
+  game_start_date: Date;            // 서버 첫 시작일 (기준점)
+  transition_active: boolean;
+  transition_blend: number;         // 0.0-1.0
+  active_weather: WeatherCondition;
+}
+
+// DB 테이블: game_season
+interface GameSeasonRow {
+  id: number;
+  game_start_date: Date;
+  current_tick: number;             // 서버 시작 후 경과 game-days
+  // current_season, day_in_season 등은 current_tick에서 계산
+}
+```
+
+### 6.2 Event Queue
+
+```typescript
+interface GameEvent {
+  id: string;                       // UUID
+  user_id: string;
+  event_type: EventCategory;
+  severity: EventSeverity;
+  payload: Record<string, any>;     // 이벤트 타입별 상세 데이터 (JSONB)
+  status: 'pending' | 'active' | 'resolved' | 'expired';
+  created_at: Date;
+  activated_at: Date | null;
+  expires_at: Date;
+  resolved_at: Date | null;
+  affected_plot_ids: string[];      // 영향받는 밭 칸 ID 목록
+}
+
+// DB 테이블: game_events
+```
+
+### 6.3 NPC State
+
+```typescript
+interface NPCState {
+  npc_id: string;
+  user_id: string;
+  affinity: number;                 // 0-100
+  affinity_level: number;           // 1-6
+  total_quests_completed: number;
+  total_quests_failed: number;
+  last_visit_date: Date | null;
+  last_quest_date: Date | null;
+  is_visiting: boolean;
+  is_unlocked: boolean;
+  permanent_buffs: string[];        // Max affinity 보상 등
+}
+
+// DB 테이블: user_npc_relations
+```
+
+### 6.4 Quest State
+
+```typescript
+interface QuestState {
+  id: string;                       // UUID
+  user_id: string;
+  npc_id: string;
+  quest_type: QuestType;
+  difficulty: string;
+  requirements: QuestRequirement[]; // JSONB
+  rewards: QuestReward;             // JSONB
+  status: 'offered' | 'accepted' | 'in_progress' | 'completed' | 'failed' | 'expired';
+  progress: QuestProgress[];        // JSONB - 각 requirement별 진행도
+  offered_at: Date;
+  accepted_at: Date | null;
+  deadline_at: Date;
+  completed_at: Date | null;
+}
+
+interface QuestProgress {
+  requirement_index: number;
+  current_quantity: number;
+  target_quantity: number;
+  current_quality: QualityGrade | null;
+  is_fulfilled: boolean;
+}
+
+// DB 테이블: quests
+```
+
+### 6.5 Contest State
+
+```typescript
+interface ContestState {
+  id: string;
+  contest_type: ContestType;
+  season: Season;
+  game_year: number;
+  status: 'announced' | 'registration' | 'in_progress' | 'judging' | 'completed';
+  participants: ContestParticipant[]; // JSONB
+  npc_scores: NPCScore[];            // JSONB
+  results: ContestResult | null;      // JSONB
+  schedule: ContestSchedule;          // JSONB
+  created_at: Date;
+}
+
+interface ContestParticipant {
+  user_id: string;
+  entries: ContestEntry[];           // 출품작
+  total_score: number | null;
+  rank: number | null;
+}
+
+// DB 테이블: contests, contest_entries
+```
+
+### 6.6 Affinity Table
+
+```typescript
+// user_npc_relations 테이블 내 관리
+interface AffinityTable {
+  user_id: string;
+  npc_id: string;
+  affinity: number;
+  level: number;
+  history: AffinityEvent[];          // JSONB - 최근 30건
+}
+
+interface AffinityEvent {
+  event_type: string;               // 'quest_complete', 'gift', 'greeting', etc.
+  delta: number;                    // +5, -3, etc.
+  timestamp: Date;
+}
+```
+
+---
+
+## 7. Algorithm Specifications
+
+### 7.1 Event Trigger Algorithm
+
+```typescript
+/**
+ * Daily Event Processor
+ * 매일 simulationCron에서 각 유저별 호출
+ */
+async function processDailyEvents(userId: string): Promise<GameEvent[]> {
+  const season = getCurrentSeason();
+  const user = await getUser(userId);
+  const activeEvents = await getActiveEvents(userId);
+  const eventHistory = await getRecentEventHistory(userId, 30); // 최근 30일
+
+  const newEvents: GameEvent[] = [];
+
+  // 동시 이벤트 제한 체크
+  if (activeEvents.length >= MAX_CONCURRENT_EVENTS) return newEvents;
+
+  // 각 이벤트 타입 순회
+  for (const eventType of EVENT_TYPES) {
+    // 쿨다운 체크
+    const lastOccurrence = eventHistory.findLast(e => e.event_type === eventType);
+    if (lastOccurrence) {
+      const daysSince = diffDays(now(), lastOccurrence.created_at);
+      if (daysSince < COOLDOWNS[eventType]) continue;
+    }
+
+    // 확률 계산
+    const baseProbability = BASE_PROBABILITIES[eventType];
+    const seasonWeight = SEASON_WEIGHTS[eventType][season];
+    const pitySince = eventHistory.length === 0 ? 10
+      : diffDays(now(), eventHistory[eventHistory.length - 1].created_at);
+    const pityFactor = Math.min(1.0 + pitySince * 0.05, 2.0);
+    const levelFactor = 1.0 + user.level * 0.01;
+    const gardenFactor = 1.0 + user.plot_count * 0.02;
+
+    const finalProbability = baseProbability * seasonWeight * pityFactor * levelFactor * gardenFactor;
+
+    // 이벤트 발생 판정
+    if (Math.random() < finalProbability) {
+      const severity = rollSeverity(eventType, season);
+      const event = await createEvent(userId, eventType, severity, season);
+      newEvents.push(event);
+
+      // 동시 이벤트 제한 재체크
+      if (activeEvents.length + newEvents.length >= MAX_CONCURRENT_EVENTS) break;
+    }
+  }
+
+  return newEvents;
+}
+```
+
+### 7.2 Probability Weight Tables
+
+```typescript
+const SEASON_WEIGHTS: Record<EventCategory, Record<Season, number>> = {
+  pest:       { spring: 1.0,  summer: 1.875, autumn: 0.75,  winter: 0.25  },
+  storm:      { spring: 0.56, summer: 1.33,  autumn: 0.89,  winter: 1.11  },
+  lucky_rain: { spring: 1.43, summer: 0.71,  autumn: 1.14,  winter: 0.43  },
+  rare_seed:  { spring: 1.2,  summer: 0.8,   autumn: 1.6,   winter: 0.4   },
+  disease:    { spring: 0.8,  summer: 1.6,   autumn: 1.0,   winter: 0.6   },
+};
+
+const SEVERITY_WEIGHTS: Record<EventCategory, Record<EventSeverity, number>> = {
+  pest:       { minor: 0.45, moderate: 0.30, major: 0.18, critical: 0.07 },
+  storm:      { minor: 0.35, moderate: 0.35, major: 0.20, critical: 0.10 },
+  lucky_rain: { minor: 0.60, moderate: 0.30, major: 0.10, critical: 0.00 },
+  rare_seed:  { minor: 0.50, moderate: 0.30, major: 0.15, critical: 0.05 },
+  disease:    { minor: 0.40, moderate: 0.35, major: 0.18, critical: 0.07 },
+};
+```
+
+### 7.3 Reward Calculation
+
+```typescript
+function calculateQuestReward(
+  quest: Quest,
+  npc: NPC,
+  user: User,
+  deliveredQuality: QualityGrade[]
+): QuestReward {
+  const difficultyMultiplier = {
+    easy: 1.0, medium: 1.5, hard: 2.5, legendary: 5.0
+  }[quest.difficulty];
+
+  const affinityLevel = getAffinityLevel(npc.affinity);
+  const affinityBonus = 1.0 + affinityLevel * 0.1;
+
+  // 품질 보너스: 요구보다 높은 등급 수
+  const qualityUpgrades = deliveredQuality.filter(
+    q => gradeToNum(q) > gradeToNum(quest.requirements[0].min_quality)
+  ).length;
+  const qualityBonus = 1.0 + qualityUpgrades * 0.2;
+
+  // 속도 보너스
+  const daysUsed = diffDays(now(), quest.accepted_at);
+  const deadline = quest.deadline_days;
+  const speedBonus = daysUsed <= deadline * 0.5 ? 1.25 : 1.0;
+
+  // 첫 퀘스트 보너스
+  const firstTimeBonus = quest.is_first_for_npc ? 2.0 : 1.0;
+
+  const coins = Math.round(
+    quest.rewards.base_coins * difficultyMultiplier * affinityBonus * qualityBonus * speedBonus
+  );
+  const experience = Math.round(
+    quest.rewards.base_xp * difficultyMultiplier * firstTimeBonus
+  );
+  const affinityGain = difficultyToAffinity(quest.difficulty);
+
+  return { coins, experience, affinity_gain: affinityGain, bonus_items: rollBonusItems(quest) };
+}
+```
+
+### 7.4 Contest Scoring Algorithm
+
+```typescript
+function calculateFlowerShowScore(entry: FlowerShowEntry): number {
+  const qualityScore = entry.quality_score / 100;      // 0-1
+  const healthScore = entry.health / 100;               // 0-1
+  const bloomScore = entry.growth_completion >= 0.9 ? 1.0 : entry.growth_completion * 0.6;
+  const careScore = entry.care_history_score / 100;     // 0-1
+  const rarityScore = RARITY_SCORES[entry.rarity] || 0.5;
+
+  return qualityScore * 0.35
+       + healthScore * 0.20
+       + bloomScore * 0.25
+       + careScore * 0.15
+       + rarityScore * 0.05;
+}
+
+function calculateHarvestFestivalScore(entry: HarvestFestivalEntry, maxValues: MaxValues): number {
+  const valueScore = entry.total_harvest_value / maxValues.value;
+  const qualityScore = averageQualityNormalized(entry.entries);
+  const varietyScore = Math.min(entry.variety_count / 3, 1.0);
+  const quantityScore = Math.min(entry.entries.reduce((s, e) => s + e.quantity, 0) / maxValues.quantity, 1.0);
+
+  return valueScore * 0.40
+       + qualityScore * 0.25
+       + varietyScore * 0.20
+       + quantityScore * 0.15;
+}
+```
+
+---
+
+## 8. Database Migration Strategy
+
+### 8.1 New Tables
+
+```sql
+-- Migration 001: Season System
+CREATE TABLE game_season (
+  id SERIAL PRIMARY KEY,
+  game_start_date TIMESTAMP NOT NULL DEFAULT NOW(),
+  current_tick INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Migration 002: Events
+CREATE TABLE game_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  event_type VARCHAR(30) NOT NULL,
+  severity VARCHAR(20) NOT NULL,
+  payload JSONB NOT NULL DEFAULT '{}',
+  status VARCHAR(20) NOT NULL DEFAULT 'pending',
+  affected_plot_ids JSONB DEFAULT '[]',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  activated_at TIMESTAMP,
+  expires_at TIMESTAMP NOT NULL,
+  resolved_at TIMESTAMP,
+
+  CONSTRAINT chk_event_type CHECK (event_type IN ('pest','storm','lucky_rain','rare_seed','disease','visitor')),
+  CONSTRAINT chk_severity CHECK (severity IN ('minor','moderate','major','critical')),
+  CONSTRAINT chk_status CHECK (status IN ('pending','active','resolved','expired'))
+);
+CREATE INDEX idx_events_user_status ON game_events(user_id, status);
+CREATE INDEX idx_events_type ON game_events(event_type);
+
+-- Migration 003: NPCs
+CREATE TABLE npcs (
+  id VARCHAR(30) PRIMARY KEY,
+  name_ko VARCHAR(50) NOT NULL,
+  name_en VARCHAR(50) NOT NULL,
+  personality VARCHAR(20) NOT NULL,
+  preferred_plants JSONB NOT NULL DEFAULT '[]',
+  preferred_quality VARCHAR(5) NOT NULL DEFAULT 'c',
+  base_visit_rate FLOAT NOT NULL DEFAULT 0.3,
+  unlock_level INTEGER NOT NULL DEFAULT 1,
+  sprite_id VARCHAR(50),
+  dialogue_pool JSONB NOT NULL DEFAULT '{}'
+);
+
+CREATE TABLE user_npc_relations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  npc_id VARCHAR(30) NOT NULL REFERENCES npcs(id),
+  affinity INTEGER NOT NULL DEFAULT 0 CHECK (affinity >= 0 AND affinity <= 100),
+  affinity_level INTEGER NOT NULL DEFAULT 1 CHECK (affinity_level >= 1 AND affinity_level <= 6),
+  total_quests_completed INTEGER NOT NULL DEFAULT 0,
+  total_quests_failed INTEGER NOT NULL DEFAULT 0,
+  last_visit_date TIMESTAMP,
+  last_quest_date TIMESTAMP,
+  is_unlocked BOOLEAN NOT NULL DEFAULT FALSE,
+  permanent_buffs JSONB DEFAULT '[]',
+  history JSONB DEFAULT '[]',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+  UNIQUE(user_id, npc_id)
+);
+CREATE INDEX idx_unr_user ON user_npc_relations(user_id);
+
+-- Migration 004: Quests
+CREATE TABLE quests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  npc_id VARCHAR(30) NOT NULL REFERENCES npcs(id),
+  quest_type VARCHAR(20) NOT NULL,
+  difficulty VARCHAR(15) NOT NULL,
+  requirements JSONB NOT NULL,
+  rewards JSONB NOT NULL,
+  progress JSONB NOT NULL DEFAULT '[]',
+  status VARCHAR(20) NOT NULL DEFAULT 'offered',
+  offered_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  accepted_at TIMESTAMP,
+  deadline_at TIMESTAMP NOT NULL,
+  completed_at TIMESTAMP,
+
+  CONSTRAINT chk_quest_status CHECK (status IN ('offered','accepted','in_progress','completed','failed','expired'))
+);
+CREATE INDEX idx_quests_user_status ON quests(user_id, status);
+CREATE INDEX idx_quests_npc ON quests(npc_id);
+
+-- Migration 005: Contests
+CREATE TABLE contests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contest_type VARCHAR(30) NOT NULL,
+  season VARCHAR(10) NOT NULL,
+  game_year INTEGER NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'announced',
+  schedule JSONB NOT NULL,
+  npc_scores JSONB DEFAULT '[]',
+  results JSONB,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT chk_contest_status CHECK (status IN ('announced','registration','in_progress','judging','completed'))
+);
+
+CREATE TABLE contest_entries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contest_id UUID NOT NULL REFERENCES contests(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  entries JSONB NOT NULL,
+  total_score FLOAT,
+  rank INTEGER,
+  prize JSONB,
+  submitted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+  UNIQUE(contest_id, user_id)
+);
+CREATE INDEX idx_ce_contest ON contest_entries(contest_id);
+
+-- Migration 006: Rare Seeds Catalog
+CREATE TABLE rare_seeds (
+  id VARCHAR(50) PRIMARY KEY,
+  name_ko VARCHAR(50) NOT NULL,
+  name_en VARCHAR(50) NOT NULL,
+  rarity VARCHAR(15) NOT NULL,
+  base_drop_rate FLOAT NOT NULL,
+  growth_days INTEGER NOT NULL,
+  sell_value INTEGER NOT NULL,
+  special_trait JSONB NOT NULL DEFAULT '{}',
+  plant_base_id VARCHAR(30) REFERENCES plants(id),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+```
+
+### 8.2 Existing Table Modifications
+
+```sql
+-- user_plants에 계절/이벤트 관련 컬럼 추가
+ALTER TABLE user_plants ADD COLUMN season_planted VARCHAR(10);
+ALTER TABLE user_plants ADD COLUMN quality_score FLOAT DEFAULT 50.0;
+ALTER TABLE user_plants ADD COLUMN care_score FLOAT DEFAULT 50.0;
+ALTER TABLE user_plants ADD COLUMN is_rare BOOLEAN DEFAULT FALSE;
+ALTER TABLE user_plants ADD COLUMN rare_seed_id VARCHAR(50) REFERENCES rare_seeds(id);
+ALTER TABLE user_plants ADD COLUMN active_buffs JSONB DEFAULT '[]';
+ALTER TABLE user_plants ADD COLUMN active_debuffs JSONB DEFAULT '[]';
+
+-- users에 이벤트/NPC 관련 컬럼 추가
+ALTER TABLE users ADD COLUMN last_event_check TIMESTAMP;
+ALTER TABLE users ADD COLUMN event_pity_counter INTEGER DEFAULT 0;
+ALTER TABLE users ADD COLUMN contest_titles JSONB DEFAULT '[]';
+```
+
+---
+
+## 9. API Endpoints
+
+### 9.1 Season API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/v1/season` | 현재 계절 정보 조회 |
+| GET | `/api/v1/season/calendar` | 연간 캘린더 (이벤트, 컨테스트 일정) |
+| GET | `/api/v1/season/modifiers` | 현재 계절 성장 보정 계수 |
+
+### 9.2 Event API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/v1/events` | 활성 이벤트 목록 조회 |
+| GET | `/api/v1/events/:id` | 이벤트 상세 조회 |
+| POST | `/api/v1/events/:id/resolve` | 이벤트 대응 (살충제 사용 등) |
+| GET | `/api/v1/events/history` | 이벤트 히스토리 (최근 30일) |
+
+### 9.3 NPC API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/v1/npcs` | NPC 목록 (해금 상태 포함) |
+| GET | `/api/v1/npcs/:id` | NPC 상세 (친밀도, 대화 등) |
+| GET | `/api/v1/npcs/visiting` | 현재 방문 중인 NPC 목록 |
+| POST | `/api/v1/npcs/:id/greet` | NPC 인사 (친밀도 +1, 일 1회) |
+| POST | `/api/v1/npcs/:id/gift` | NPC에게 식물 선물 |
+
+### 9.4 Quest API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/v1/quests` | 활성 퀘스트 목록 |
+| GET | `/api/v1/quests/:id` | 퀘스트 상세 (진행도 포함) |
+| POST | `/api/v1/quests/:id/accept` | 퀘스트 수락 |
+| POST | `/api/v1/quests/:id/deliver` | 작물 납품 |
+| POST | `/api/v1/quests/:id/abandon` | 퀘스트 포기 |
+| GET | `/api/v1/quests/history` | 퀘스트 히스토리 |
+
+### 9.5 Contest API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/v1/contests` | 컨테스트 목록 (현재/예정) |
+| GET | `/api/v1/contests/:id` | 컨테스트 상세 |
+| POST | `/api/v1/contests/:id/register` | 참가 등록 |
+| POST | `/api/v1/contests/:id/submit` | 출품작 제출 |
+| GET | `/api/v1/contests/:id/results` | 결과 조회 |
+| GET | `/api/v1/contests/history` | 참가 이력 |
+
+---
+
+## 10. Frontend Components
+
+### 10.1 Component Hierarchy
+
+```
+App
+├── SeasonOverlay                  // 계절 배경 + 파티클
+│   ├── SeasonBackground           // 배경색/이미지 전환
+│   ├── ParticleSystem             // 벚꽃/눈/낙엽 파티클
+│   └── SeasonTransitionEffect     // 전환 블렌드 효과
+│
+├── EventNotificationPanel         // 이벤트 알림
+│   ├── EventCard                  // 개별 이벤트 카드
+│   ├── EventDetailModal           // 이벤트 상세 + 대응 UI
+│   └── EventHistory               // 이벤트 이력
+│
+├── NPCPanel                      // NPC 영역
+│   ├── NPCVisitorList             // 방문 중인 NPC 목록
+│   ├── NPCProfileModal            // NPC 상세 프로필
+│   ├── NPCDialogueBox             // 대화 UI
+│   ├── AffinityMeter              // 친밀도 게이지
+│   └── QuestBoard                 // 퀘스트 보드
+│       ├── QuestCard              // 퀘스트 카드
+│       ├── QuestDetailModal       // 퀘스트 상세 + 납품
+│       └── QuestProgressTracker   // 진행도 트래커
+│
+├── ContestCenter                  // 컨테스트 센터
+│   ├── ContestCalendar            // 캘린더 뷰
+│   ├── ContestRegistration        // 참가 등록
+│   ├── ContestSubmission          // 출품 UI
+│   ├── ContestLeaderboard         // 순위표
+│   └── ContestResultModal         // 결과 발표
+│
+└── SeasonInfoWidget               // 사이드바 계절 정보
+    ├── SeasonClock                // 현재 계절 + 남은 일수
+    ├── GrowthModifierDisplay      // 성장 보정 표시
+    └── UpcomingEventsPreview      // 예정 이벤트 미리보기
+```
+
+### 10.2 State Management (Redux Slices)
+
+```typescript
+// store/slices/seasonSlice.ts
+interface SeasonState {
+  currentSeason: Season;
+  dayInSeason: number;
+  gameYear: number;
+  transition: { active: boolean; blend: number };
+  modifiers: Record<string, SeasonModifiers>;
+}
+
+// store/slices/eventSlice.ts
+interface EventState {
+  activeEvents: GameEvent[];
+  recentHistory: GameEvent[];
+  notifications: EventNotification[];
+}
+
+// store/slices/npcSlice.ts
+interface NPCSliceState {
+  npcs: NPC[];
+  visitingNPCs: string[];
+  relations: Record<string, NPCRelation>;
+  activeQuests: Quest[];
+  questHistory: Quest[];
+}
+
+// store/slices/contestSlice.ts
+interface ContestState {
+  currentContest: Contest | null;
+  upcomingContests: Contest[];
+  myEntries: ContestEntry[];
+  results: ContestResult[];
+}
+```
+
+---
+
+## 11. Implementation Roadmap
+
+### 11.1 Phase Plan
+
+```
+Phase 3-A: Season Cycle System (2 weeks)
+├── Task 1: DB migration (game_season) + Season calculation service
+├── Task 2: Season modifier engine integration into simulation.service.ts
+├── Task 3: Season API endpoints
+├── Task 4: Frontend SeasonOverlay + CSS variables
+├── Task 5: Particle system (cherry blossom, snow, leaves)
+└── Task 6: Season transition blending + testing
+
+Phase 3-B: Random Event System (2.5 weeks)
+├── Task 1: DB migration (game_events, rare_seeds)
+├── Task 2: Event scheduler service + probability engine
+├── Task 3: Pest/Storm/LuckyRain/RareSeed event handlers
+├── Task 4: Event API endpoints
+├── Task 5: simulationCron.ts integration (daily event processing)
+├── Task 6: Frontend EventNotificationPanel + EventDetailModal
+└── Task 7: Event countermeasure system (item usage)
+
+Phase 3-C: NPC Customer System (3 weeks)
+├── Task 1: DB migration (npcs, user_npc_relations, quests)
+├── Task 2: NPC seed data + visit scheduling service
+├── Task 3: Quest generation engine
+├── Task 4: Affinity system + milestone rewards
+├── Task 5: Quest completion + reward distribution
+├── Task 6: NPC/Quest API endpoints
+├── Task 7: Frontend NPCPanel + DialogueBox
+├── Task 8: Frontend QuestBoard + QuestProgressTracker
+└── Task 9: AffinityMeter + NPC profile UI
+
+Phase 3-D: Season Contest System (2 weeks)
+├── Task 1: DB migration (contests, contest_entries)
+├── Task 2: Contest scheduler + auto-lifecycle management
+├── Task 3: Scoring algorithms (FlowerShow, HarvestFestival)
+├── Task 4: NPC competitor generation
+├── Task 5: Contest API endpoints
+├── Task 6: Frontend ContestCenter + Leaderboard
+└── Task 7: Prize distribution + title system
+
+Phase 3-E: Integration & Polish (1 week)
+├── Task 1: Cross-system integration testing
+├── Task 2: Balance tuning (probabilities, rewards, difficulty)
+├── Task 3: Edge case handling + error states
+└── Task 4: Performance optimization (query indexing, caching)
+```
+
+### 11.2 Development Priority
+
+| Priority | Module | Estimated Duration | Dependencies |
+|----------|--------|-------------------|-------------|
+| P0 (Critical) | Season Cycle System | 2 weeks | Phase 1 simulation engine |
+| P0 (Critical) | Random Event System | 2.5 weeks | Season Cycle System |
+| P1 (High) | NPC Customer System | 3 weeks | Phase 2 Economy |
+| P2 (Medium) | Season Contest System | 2 weeks | Season + NPC |
+| P2 (Medium) | Integration & Polish | 1 week | All above |
+
+**Total Estimated Duration: 10.5 weeks**
+
+### 11.3 Key Milestones
+
+| Week | Milestone | Deliverable |
+|------|-----------|-------------|
+| W2 | Season MVP | 계절 전환 작동, 성장 보정 적용, 배경 변경 |
+| W4.5 | Events MVP | 5종 이벤트 발생/해결, 이벤트 UI 표시 |
+| W7.5 | NPC MVP | NPC 방문/퀘스트/친밀도 전체 루프 작동 |
+| W9.5 | Contest MVP | 꽃 품평회 + 수확 축제 전체 루프 작동 |
+| W10.5 | Phase 3 Complete | 전체 통합, 밸런스 조정, QA 완료 |
+
+---
+
+## 12. Risk & Open Questions
+
+### 12.1 Risks
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| 밸런스 붕괴 (보상 과다/과소) | High | Medium | 테스트 서버에서 시뮬레이션 1000회 돌려 분포 확인 |
+| 이벤트 스팸 (사용자 피로감) | Medium | Low | 쿨다운 + 동시 이벤트 제한 + 이벤트 무시 기능 |
+| NPC 퀘스트 불가능 조건 | Medium | Medium | 퀘스트 생성 시 유저 보유 식물 기반 필터링 |
+| 컨테스트 NPC 점수 불공정 | Low | Low | 유저 레벨 기반 스케일링 + 분산 조정 |
+| DB 성능 (JSONB 쿼리 부하) | Medium | Low | 인덱싱 전략 + 주요 필드 별도 컬럼화 |
+
+### 12.2 Open Questions
+
+1. **게임 시간 가속**: 사용자가 오프라인인 동안 이벤트 처리를 어떻게 할 것인가?
+   - 제안: 로그인 시 미처리 일수만큼 일괄 처리 (최대 7일치)
+
+2. **계절 리셋 시점**: 서버 전체 공유 vs 유저별 독립 계절?
+   - 제안: 서버 전체 공유 (커뮤니티 이벤트 연동 가능)
+
+3. **NPC 대화 시스템 깊이**: 단순 텍스트 vs 분기 대화?
+   - 제안: Phase 3에서는 단순 텍스트 풀, Phase 4에서 분기 대화 확장
+
+4. **멀티플레이어 컨테스트**: 다른 유저와 직접 경쟁 vs NPC 경쟁만?
+   - 제안: Phase 3에서는 NPC 경쟁만, 멀티플레이어는 Phase 4+
+
+5. **희귀 씨앗 거래**: 유저 간 거래 허용 여부?
+   - 제안: Phase 3에서는 비거래 (Bind on Pickup), 추후 거래소 검토
+
+---
+
+## Appendix A: Season Growth Modifier Quick Reference
+
+```json
+{
+  "season_modifiers": {
+    "spring": {
+      "flowering": { "growth": 1.3, "yield": 1.2, "quality": 1.3 },
+      "succulent": { "growth": 1.0, "yield": 1.0, "quality": 1.0 },
+      "herb":      { "growth": 1.4, "yield": 1.3, "quality": 1.2 },
+      "leafy":     { "growth": 1.3, "yield": 1.2, "quality": 1.2 },
+      "fruit":     { "growth": 1.1, "yield": 1.0, "quality": 1.0 },
+      "foliage":   { "growth": 1.1, "yield": 1.0, "quality": 1.0 }
+    },
+    "summer": {
+      "flowering": { "growth": 1.1, "yield": 1.0, "quality": 0.9 },
+      "succulent": { "growth": 1.2, "yield": 1.1, "quality": 1.0 },
+      "herb":      { "growth": 1.2, "yield": 1.1, "quality": 1.0 },
+      "leafy":     { "growth": 0.8, "yield": 0.7, "quality": 0.7 },
+      "fruit":     { "growth": 1.4, "yield": 1.5, "quality": 1.2 },
+      "foliage":   { "growth": 1.2, "yield": 1.0, "quality": 1.0 }
+    },
+    "autumn": {
+      "flowering": { "growth": 0.7, "yield": 0.8, "quality": 1.1 },
+      "succulent": { "growth": 0.9, "yield": 0.9, "quality": 1.0 },
+      "herb":      { "growth": 0.8, "yield": 0.9, "quality": 1.1 },
+      "leafy":     { "growth": 1.1, "yield": 1.1, "quality": 1.3 },
+      "fruit":     { "growth": 0.9, "yield": 1.2, "quality": 1.4 },
+      "foliage":   { "growth": 0.9, "yield": 0.9, "quality": 1.0 }
+    },
+    "winter": {
+      "flowering": { "growth": 0.3, "yield": 0.4, "quality": 0.6 },
+      "succulent": { "growth": 0.6, "yield": 0.7, "quality": 0.8 },
+      "herb":      { "growth": 0.2, "yield": 0.3, "quality": 0.5 },
+      "leafy":     { "growth": 0.4, "yield": 0.5, "quality": 0.6 },
+      "fruit":     { "growth": 0.1, "yield": 0.2, "quality": 0.4 },
+      "foliage":   { "growth": 0.5, "yield": 0.5, "quality": 0.7 }
+    }
+  }
+}
+```
+
+## Appendix B: Event Probability Summary (per game-day)
+
+```json
+{
+  "event_probabilities_per_day": {
+    "pest":       { "spring": 0.080, "summer": 0.150, "autumn": 0.060, "winter": 0.020 },
+    "storm":      { "spring": 0.050, "summer": 0.120, "autumn": 0.080, "winter": 0.100 },
+    "lucky_rain": { "spring": 0.100, "summer": 0.050, "autumn": 0.080, "winter": 0.030 },
+    "rare_seed":  { "spring": 0.030, "summer": 0.020, "autumn": 0.040, "winter": 0.010 },
+    "disease":    { "spring": 0.040, "summer": 0.080, "autumn": 0.050, "winter": 0.030 },
+    "note": "Base probabilities before pity/level/garden_size modifiers"
+  }
+}
+```
+
+## Appendix C: NPC Affinity Thresholds
+
+```json
+{
+  "affinity_levels": [
+    { "level": 1, "min": 0,  "max": 19,  "title": "낯선 사이",   "reward_bonus": 1.0 },
+    { "level": 2, "min": 20, "max": 39,  "title": "아는 사이",   "reward_bonus": 1.1 },
+    { "level": 3, "min": 40, "max": 59,  "title": "친한 사이",   "reward_bonus": 1.2 },
+    { "level": 4, "min": 60, "max": 79,  "title": "절친한 사이", "reward_bonus": 1.3 },
+    { "level": 5, "min": 80, "max": 99,  "title": "소울메이트",  "reward_bonus": 1.5 },
+    { "level": 6, "min": 100, "max": 100, "title": "영혼의 벗",  "reward_bonus": 1.5 }
+  ]
+}
+```
+
+---
+
+> **Document End**
+> Next Step: Phase 3-A 구현 시작 (Season Cycle System)


### PR DESCRIPTION
## Summary
- 마일스톤 #6 (이벤트 & NPC) 설계 명세 + 검증 리포트 추가
- 마일스톤 #7 (도감·업적·회차) 설계 명세 추가

기존 `milestone/a6d7a688-*`, `milestone/f62a0f8e-*` 브랜치에서 **신규 문서만 cherry-pick**. 해당 브랜치들에 포함돼있던 obsolete 문서 삭제는 의도가 불분명해 제외.

## Test plan
- [ ] 문서만 추가하는 변경이라 기능 영향 없음
- [x] 브랜치 충돌 없음 (main 최신 기준 분기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)